### PR TITLE
Ftr: rpc timeout

### DIFF
--- a/autowire/normal/normal.go
+++ b/autowire/normal/normal.go
@@ -82,3 +82,7 @@ func RegisterStructDescriptor(s *autowire.StructDescriptor) {
 func GetImpl(sdID string, param interface{}) (interface{}, error) {
 	return autowire.Impl(Name, sdID, param)
 }
+
+func GetImplWithProxy(sdID string, param interface{}) (interface{}, error) {
+	return autowire.ImplWithProxy(Name, sdID, param)
+}

--- a/common/constant.go
+++ b/common/constant.go
@@ -1,0 +1,5 @@
+package common
+
+const (
+	AliasKey = "alias"
+)

--- a/debug/interceptor/edit_interceptor_test.go
+++ b/debug/interceptor/edit_interceptor_test.go
@@ -88,7 +88,7 @@ func TestEditInterceptorWithCondition(t *testing.T) {
 	assert.Equal(t, serviceFooStructID, info.ImplementationName)
 	assert.Equal(t, "Invoke", info.MethodName)
 	assert.Equal(t, true, info.IsParam)
-	assert.True(t, strings.Contains(info.Params[1], "lizhixin"))
+	assert.True(t, strings.Contains(info.Params[2], "lizhixin"))
 
 	assert.Nil(t, err)
 	assert.Equal(t, "laurence", rsp.Name)

--- a/debug/interceptor/edit_interceptor_test.go
+++ b/debug/interceptor/edit_interceptor_test.go
@@ -53,7 +53,7 @@ func TestEditInterceptorWithCondition(t *testing.T) {
 		SendCh: sendCh,
 		RecvCh: recvCh,
 		FieldMatcher: &FieldMatcher{
-			FieldIndex: 2,
+			FieldIndex: 1,
 			MatchRule:  "User.Name=lizhixin",
 		},
 	})
@@ -68,14 +68,14 @@ func TestEditInterceptorWithCondition(t *testing.T) {
 	}
 	go func() {
 		controlRecvCh <- &EditData{
-			FieldIndex: 2,
+			FieldIndex: 1,
 			FieldPath:  "User.Name",
 			Value:      "laurence",
 		}
 	}()
 
 	editInterceptor.Invoke(interfaceImplId, methodName, true,
-		[]reflect.Value{reflect.ValueOf(service), reflect.ValueOf(ctx), reflect.ValueOf(param)})
+		[]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(param)})
 
 	rsp, err := service.Invoke(ctx, param)
 
@@ -88,7 +88,7 @@ func TestEditInterceptorWithCondition(t *testing.T) {
 	assert.Equal(t, serviceFooStructID, info.ImplementationName)
 	assert.Equal(t, "Invoke", info.MethodName)
 	assert.Equal(t, true, info.IsParam)
-	assert.True(t, strings.Contains(info.Params[2], "lizhixin"))
+	assert.True(t, strings.Contains(info.Params[1], "lizhixin"))
 
 	assert.Nil(t, err)
 	assert.Equal(t, "laurence", rsp.Name)

--- a/debug/interceptor/watch_interceptor.go
+++ b/debug/interceptor/watch_interceptor.go
@@ -54,10 +54,6 @@ func sendValues(interfaceImplId, methodName string, isParam bool, values []refle
 		ImplementationName: interfaceImplId,
 	}
 	i := 0
-	if isParam {
-		// param first value is struct ptr, should skip it.
-		i = 1
-	}
 	for ; i < len(values); i++ {
 		if !values[i].IsValid() {
 			invokeDetail.Params = append(invokeDetail.Params, "nil")

--- a/debug/monkey.go
+++ b/debug/monkey.go
@@ -77,7 +77,7 @@ func makeCallProxy(tempInterfaceId, methodName string, isVariadic bool) func(in 
 		}()
 		// interceptor
 		for _, i := range paramInterceptors {
-			in = i.Invoke(tempInterfaceId, methodName, true, in)
+			in = i.Invoke(tempInterfaceId, methodName, true, in[1:])
 		}
 
 		if isVariadic {

--- a/example/autowire_config/cmd/zz_generated.ioc.go
+++ b/example/autowire_config/cmd/zz_generated.ioc.go
@@ -47,5 +47,10 @@ func GetApp() (*App, error) {
 	return impl, nil
 }
 func GetAppIOCInterface() (AppIOCInterface, error) {
-	return GetApp()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(AppIOCInterface)
+	return impl, nil
 }

--- a/example/autowire_gorm_db/cmd/zz_generated.ioc.go
+++ b/example/autowire_gorm_db/cmd/zz_generated.ioc.go
@@ -47,5 +47,10 @@ func GetApp() (*App, error) {
 	return impl, nil
 }
 func GetAppIOCInterface() (AppIOCInterface, error) {
-	return GetApp()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(AppIOCInterface)
+	return impl, nil
 }

--- a/example/autowire_grpc_client/cmd/service1/zz_generated.ioc.go
+++ b/example/autowire_grpc_client/cmd/service1/zz_generated.ioc.go
@@ -46,5 +46,10 @@ func GetImpl1() (*Impl1, error) {
 	return impl, nil
 }
 func GetImpl1IOCInterface() (Impl1IOCInterface, error) {
-	return GetImpl1()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl1)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(Impl1IOCInterface)
+	return impl, nil
 }

--- a/example/autowire_grpc_client/cmd/service2/zz_generated.ioc.go
+++ b/example/autowire_grpc_client/cmd/service2/zz_generated.ioc.go
@@ -67,7 +67,12 @@ func GetImpl1() (*Impl1, error) {
 	return impl, nil
 }
 func GetImpl1IOCInterface() (Impl1IOCInterface, error) {
-	return GetImpl1()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl1)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(Impl1IOCInterface)
+	return impl, nil
 }
 func GetImpl2() (*Impl2, error) {
 	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(Impl2)), nil)
@@ -78,5 +83,10 @@ func GetImpl2() (*Impl2, error) {
 	return impl, nil
 }
 func GetImpl2IOCInterface() (Impl2IOCInterface, error) {
-	return GetImpl2()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl2)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(Impl2IOCInterface)
+	return impl, nil
 }

--- a/example/autowire_grpc_client/cmd/struct1/zz_generated.ioc.go
+++ b/example/autowire_grpc_client/cmd/struct1/zz_generated.ioc.go
@@ -46,5 +46,10 @@ func GetStruct1() (*Struct1, error) {
 	return impl, nil
 }
 func GetStruct1IOCInterface() (Struct1IOCInterface, error) {
-	return GetStruct1()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Struct1)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(Struct1IOCInterface)
+	return impl, nil
 }

--- a/example/autowire_grpc_client/cmd/zz_generated.ioc.go
+++ b/example/autowire_grpc_client/cmd/zz_generated.ioc.go
@@ -47,5 +47,10 @@ func GetApp() (*App, error) {
 	return impl, nil
 }
 func GetAppIOCInterface() (AppIOCInterface, error) {
-	return GetApp()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(AppIOCInterface)
+	return impl, nil
 }

--- a/example/autowire_nacos_client/cmd/zz_generated.ioc.go
+++ b/example/autowire_nacos_client/cmd/zz_generated.ioc.go
@@ -59,5 +59,10 @@ func GetApp(p *Param) (*App, error) {
 	return impl, nil
 }
 func GetAppIOCInterface(p *Param) (AppIOCInterface, error) {
-	return GetApp(p)
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), p)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(AppIOCInterface)
+	return impl, nil
 }

--- a/example/autowire_redis_client/cmd/zz_generated.ioc.go
+++ b/example/autowire_redis_client/cmd/zz_generated.ioc.go
@@ -59,5 +59,10 @@ func GetApp(p *Param) (*App, error) {
 	return impl, nil
 }
 func GetAppIOCInterface(p *Param) (AppIOCInterface, error) {
-	return GetApp(p)
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), p)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(AppIOCInterface)
+	return impl, nil
 }

--- a/example/autowire_rpc/client/test/service/zz_generated.ioc.go
+++ b/example/autowire_rpc/client/test/service/zz_generated.ioc.go
@@ -100,7 +100,12 @@ func GetComplexService() (*ComplexService, error) {
 	return impl, nil
 }
 func GetComplexServiceIOCInterface() (ComplexServiceIOCInterface, error) {
-	return GetComplexService()
+	i, err := rpc_service.GetImplWithProxy(util.GetSDIDByStructPtr(new(ComplexService)))
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(ComplexServiceIOCInterface)
+	return impl, nil
 }
 func GetSimpleService() (*SimpleService, error) {
 	i, err := rpc_service.GetImpl(util.GetSDIDByStructPtr(new(SimpleService)))
@@ -111,5 +116,10 @@ func GetSimpleService() (*SimpleService, error) {
 	return impl, nil
 }
 func GetSimpleServiceIOCInterface() (SimpleServiceIOCInterface, error) {
-	return GetSimpleService()
+	i, err := rpc_service.GetImplWithProxy(util.GetSDIDByStructPtr(new(SimpleService)))
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(SimpleServiceIOCInterface)
+	return impl, nil
 }

--- a/example/autowire_rpc/client/zz_generated.ioc.go
+++ b/example/autowire_rpc/client/zz_generated.ioc.go
@@ -46,5 +46,10 @@ func GetApp() (*App, error) {
 	return impl, nil
 }
 func GetAppIOCInterface() (AppIOCInterface, error) {
-	return GetApp()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(AppIOCInterface)
+	return impl, nil
 }

--- a/example/autowire_rpc/server/pkg/service/zz_generated.ioc.go
+++ b/example/autowire_rpc/server/pkg/service/zz_generated.ioc.go
@@ -48,5 +48,10 @@ func GetServiceStruct() (*ServiceStruct, error) {
 	return impl, nil
 }
 func GetServiceStructIOCInterface() (ServiceStructIOCInterface, error) {
-	return GetServiceStruct()
+	i, err := rpc_service.GetImplWithProxy(util.GetSDIDByStructPtr(new(ServiceStruct)))
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(ServiceStructIOCInterface)
+	return impl, nil
 }

--- a/example/debug/cmd/service1/zz_generated.ioc.go
+++ b/example/debug/cmd/service1/zz_generated.ioc.go
@@ -46,5 +46,10 @@ func GetImpl1() (*Impl1, error) {
 	return impl, nil
 }
 func GetImpl1IOCInterface() (Impl1IOCInterface, error) {
-	return GetImpl1()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl1)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(Impl1IOCInterface)
+	return impl, nil
 }

--- a/example/debug/cmd/service2/zz_generated.ioc.go
+++ b/example/debug/cmd/service2/zz_generated.ioc.go
@@ -67,7 +67,12 @@ func GetImpl1() (*Impl1, error) {
 	return impl, nil
 }
 func GetImpl1IOCInterface() (Impl1IOCInterface, error) {
-	return GetImpl1()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl1)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(Impl1IOCInterface)
+	return impl, nil
 }
 func GetImpl2() (*Impl2, error) {
 	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(Impl2)), nil)
@@ -78,5 +83,10 @@ func GetImpl2() (*Impl2, error) {
 	return impl, nil
 }
 func GetImpl2IOCInterface() (Impl2IOCInterface, error) {
-	return GetImpl2()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl2)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(Impl2IOCInterface)
+	return impl, nil
 }

--- a/example/debug/cmd/struct1/zz_generated.ioc.go
+++ b/example/debug/cmd/struct1/zz_generated.ioc.go
@@ -46,5 +46,10 @@ func GetStruct1() (*Struct1, error) {
 	return impl, nil
 }
 func GetStruct1IOCInterface() (Struct1IOCInterface, error) {
-	return GetStruct1()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Struct1)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(Struct1IOCInterface)
+	return impl, nil
 }

--- a/example/debug/cmd/zz_generated.ioc.go
+++ b/example/debug/cmd/zz_generated.ioc.go
@@ -46,5 +46,10 @@ func GetApp() (*App, error) {
 	return impl, nil
 }
 func GetAppIOCInterface() (AppIOCInterface, error) {
-	return GetApp()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(AppIOCInterface)
+	return impl, nil
 }

--- a/example/get_impl_by_api/cmd/zz_generated.ioc.go
+++ b/example/get_impl_by_api/cmd/zz_generated.ioc.go
@@ -47,5 +47,10 @@ func GetApp() (*App, error) {
 	return impl, nil
 }
 func GetAppIOCInterface() (AppIOCInterface, error) {
-	return GetApp()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(AppIOCInterface)
+	return impl, nil
 }

--- a/example/helloworld/zz_generated.ioc.go
+++ b/example/helloworld/zz_generated.ioc.go
@@ -109,7 +109,12 @@ func GetApp() (*App, error) {
 	return impl, nil
 }
 func GetAppIOCInterface() (AppIOCInterface, error) {
-	return GetApp()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(AppIOCInterface)
+	return impl, nil
 }
 func GetServiceImpl1() (*ServiceImpl1, error) {
 	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(ServiceImpl1)), nil)
@@ -120,7 +125,12 @@ func GetServiceImpl1() (*ServiceImpl1, error) {
 	return impl, nil
 }
 func GetServiceImpl1IOCInterface() (ServiceImpl1IOCInterface, error) {
-	return GetServiceImpl1()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(ServiceImpl1)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(ServiceImpl1IOCInterface)
+	return impl, nil
 }
 func GetServiceImpl2() (*ServiceImpl2, error) {
 	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(ServiceImpl2)), nil)
@@ -131,7 +141,12 @@ func GetServiceImpl2() (*ServiceImpl2, error) {
 	return impl, nil
 }
 func GetServiceImpl2IOCInterface() (ServiceImpl2IOCInterface, error) {
-	return GetServiceImpl2()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(ServiceImpl2)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(ServiceImpl2IOCInterface)
+	return impl, nil
 }
 func GetServiceStruct() (*ServiceStruct, error) {
 	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(ServiceStruct)), nil)
@@ -142,5 +157,10 @@ func GetServiceStruct() (*ServiceStruct, error) {
 	return impl, nil
 }
 func GetServiceStructIOCInterface() (ServiceStructIOCInterface, error) {
-	return GetServiceStruct()
+	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(ServiceStruct)), nil)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(ServiceStructIOCInterface)
+	return impl, nil
 }

--- a/extension/autowire/rpc/protocol/protocol_impl/param.go
+++ b/extension/autowire/rpc/protocol/protocol_impl/param.go
@@ -2,11 +2,13 @@ package protocol_impl
 
 type Param struct {
 	Address    string
+	Timeout    string
 	ExportPort string
 }
 
 func (p *Param) Init(iocProtocol *IOCProtocol) (*IOCProtocol, error) {
 	iocProtocol.address = p.Address
 	iocProtocol.exportPort = p.ExportPort
+	iocProtocol.timeout = p.Timeout
 	return iocProtocol, nil
 }

--- a/extension/autowire/rpc/protocol/protocol_impl/zz_generated.ioc.go
+++ b/extension/autowire/rpc/protocol/protocol_impl/zz_generated.ioc.go
@@ -7,7 +7,6 @@ package protocol_impl
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/protocol"
-
 	autowire "github.com/alibaba/ioc-golang/autowire"
 	normal "github.com/alibaba/ioc-golang/autowire/normal"
 	util "github.com/alibaba/ioc-golang/autowire/util"
@@ -64,5 +63,10 @@ func GetIOCProtocol(p *Param) (*IOCProtocol, error) {
 	return impl, nil
 }
 func GetIOCProtocolIOCInterface(p *Param) (IOCProtocolIOCInterface, error) {
-	return GetIOCProtocol(p)
+	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(IOCProtocol)), p)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(IOCProtocolIOCInterface)
+	return impl, nil
 }

--- a/extension/autowire/rpc/rpc_client/param.go
+++ b/extension/autowire/rpc/rpc_client/param.go
@@ -17,4 +17,5 @@ package rpc_client
 
 type Param struct {
 	Address string
+	Timeout string
 }

--- a/extension/autowire/rpc/rpc_client/param_loader.go
+++ b/extension/autowire/rpc/rpc_client/param_loader.go
@@ -1,0 +1,38 @@
+package rpc_client
+
+import (
+	"github.com/alibaba/ioc-golang/autowire"
+	"github.com/alibaba/ioc-golang/autowire/param_loader"
+)
+
+var defaultParamLoaderSingleton autowire.ParamLoader
+
+func getDefaultParamLoader() autowire.ParamLoader {
+	if defaultParamLoaderSingleton == nil {
+		defaultParamLoaderSingleton = &paramLoader{
+			defaultConfigParamLoader:     getConfigParamLoader(),
+			defaultTagParamLoader:        param_loader.GetDefaultTagParamLoader(),
+			defaultTagPointToParamLoader: getTagPointToConfigParamLoader(),
+		}
+	}
+	return defaultParamLoaderSingleton
+}
+
+type paramLoader struct {
+	defaultConfigParamLoader     autowire.ParamLoader
+	defaultTagParamLoader        autowire.ParamLoader
+	defaultTagPointToParamLoader autowire.ParamLoader
+}
+
+func (d *paramLoader) Load(sd *autowire.StructDescriptor, fi *autowire.FieldInfo) (interface{}, error) {
+	if param, err := d.defaultTagPointToParamLoader.Load(sd, fi); err == nil {
+		return param, nil
+	}
+	// todo log warning
+	if param, err := d.defaultTagParamLoader.Load(sd, fi); err == nil {
+		return param, nil
+	}
+	// todo log warning
+
+	return d.defaultConfigParamLoader.Load(sd, fi)
+}

--- a/extension/autowire/rpc/rpc_client/param_loader_config.go
+++ b/extension/autowire/rpc/rpc_client/param_loader_config.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, Alibaba Group;
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc_client
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/alibaba/ioc-golang/autowire"
+	"github.com/alibaba/ioc-golang/autowire/util"
+	"github.com/alibaba/ioc-golang/config"
+)
+
+type configParamLoader struct {
+}
+
+func getConfigParamLoaderPrefix(sd *autowire.StructDescriptor) string {
+	structConfigPathKey := sd.Alias
+	if structConfigPathKey == "" {
+		structConfigPathKey, _ = util.ToRPCClientStubInterfaceSDID(util.GetSDIDByStructPtr(sd.Factory()))
+	}
+	return fmt.Sprintf("autowire%[1]s%[2]s%[1]s<%[3]s>%[1]sparam", config.YamlConfigSeparator, sd.AutowireType(), structConfigPathKey)
+}
+
+var configParamLoaderSingleton autowire.ParamLoader
+
+func getConfigParamLoader() autowire.ParamLoader {
+	if configParamLoaderSingleton == nil {
+		configParamLoaderSingleton = &configParamLoader{}
+	}
+	return configParamLoaderSingleton
+}
+
+func (p *configParamLoader) Load(sd *autowire.StructDescriptor, fi *autowire.FieldInfo) (interface{}, error) {
+	if sd == nil || sd.ParamFactory == nil {
+		return nil, errors.New("not supporterd")
+	}
+	param := sd.ParamFactory()
+	prefix := getConfigParamLoaderPrefix(sd)
+	if err := config.LoadConfigByPrefix(prefix, param); err != nil {
+		return nil, err
+	}
+	return param, nil
+}

--- a/extension/autowire/rpc/rpc_client/param_loader_tag_point_to_config.go
+++ b/extension/autowire/rpc/rpc_client/param_loader_tag_point_to_config.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, Alibaba Group;
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc_client
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/alibaba/ioc-golang/autowire"
+	"github.com/alibaba/ioc-golang/autowire/util"
+	"github.com/alibaba/ioc-golang/config"
+)
+
+type tagPointToConfigParamLoader struct {
+}
+
+func getTagPointToConfigPrefix(sd *autowire.StructDescriptor, instanceName string) string {
+	pointToKey := sd.Alias
+	if pointToKey == "" {
+		pointToKey, _ = util.ToRPCClientStubInterfaceSDID(util.GetSDIDByStructPtr(sd.Factory()))
+	}
+	return fmt.Sprintf("autowire%[1]s%[2]s%[1]s<%[3]s>%[1]s%[4]s%[1]sparam", config.YamlConfigSeparator, sd.AutowireType(), pointToKey, instanceName)
+}
+
+var tagPointToConfigSingleton autowire.ParamLoader
+
+func getTagPointToConfigParamLoader() autowire.ParamLoader {
+	if tagPointToConfigSingleton == nil {
+		tagPointToConfigSingleton = &tagPointToConfigParamLoader{}
+	}
+	return tagPointToConfigSingleton
+}
+
+func (p *tagPointToConfigParamLoader) Load(sd *autowire.StructDescriptor, fi *autowire.FieldInfo) (interface{}, error) {
+	if fi == nil || sd == nil || sd.ParamFactory == nil {
+		return nil, errors.New("not supported")
+	}
+
+	param := sd.ParamFactory()
+
+	splitedTagValue := strings.Split(fi.TagValue, ",")
+	if len(splitedTagValue) < 2 {
+		return nil, errors.New("tag value not supported")
+	}
+	prefix := getTagPointToConfigPrefix(sd, splitedTagValue[1])
+	if err := config.LoadConfigByPrefix(prefix, param); err != nil {
+		return nil, err
+	}
+	return param, nil
+}

--- a/extension/autowire/rpc/rpc_client/rpc_client.go
+++ b/extension/autowire/rpc/rpc_client/rpc_client.go
@@ -28,7 +28,7 @@ func init() {
 	autowire.RegisterAutowire(func() autowire.Autowire {
 		rpcAutowire := &Autowire{}
 		// todo parse rpc param
-		rpcAutowire.Autowire = normal.NewNormalAutowire(&sdidParser{}, nil, rpcAutowire)
+		rpcAutowire.Autowire = normal.NewNormalAutowire(&sdidParser{}, getDefaultParamLoader(), rpcAutowire)
 		return rpcAutowire
 	}())
 }
@@ -64,6 +64,7 @@ func RegisterStructDescriptor(s *autowire.StructDescriptor) {
 		param := p.(*Param)
 		iocProtocolImpl, err := protocol_impl.GetIOCProtocol(&protocol_impl.Param{
 			Address: param.Address,
+			Timeout: param.Timeout,
 		})
 		if err != nil {
 			return nil, err

--- a/extension/autowire/rpc/rpc_client/rpc_client_test.go
+++ b/extension/autowire/rpc/rpc_client/rpc_client_test.go
@@ -18,6 +18,8 @@ package rpc_client
 import (
 	"testing"
 
+	"github.com/alibaba/ioc-golang/autowire/util"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/alibaba/ioc-golang/autowire"
@@ -25,8 +27,6 @@ import (
 
 type mockImpl struct {
 }
-
-const mockImplName = "github.com/alibaba/ioc-golang/extension/autowire/rpc/rpc_client.mockImpl"
 
 func TestAutowire_RegisterAndGetAllStructDescriptors(t *testing.T) {
 	t.Run("test register and get all struct descriptors", func(t *testing.T) {
@@ -39,7 +39,8 @@ func TestAutowire_RegisterAndGetAllStructDescriptors(t *testing.T) {
 		a := &Autowire{}
 		allStructDesc := a.GetAllStructDescriptors()
 		assert.NotNil(t, allStructDesc)
-		structDesc, ok := allStructDesc[mockImplName]
+		mockImplName := util.GetSDIDByStructPtr(&mockImpl{})
+		structDesc, ok := allStructDesc[util.GetSDIDByStructPtr(&mockImpl{})]
 		assert.True(t, ok)
 		assert.Equal(t, mockImplName, structDesc.ID())
 	})

--- a/extension/normal/http_server/zz_generated.ioc.go
+++ b/extension/normal/http_server/zz_generated.ioc.go
@@ -7,14 +7,12 @@ package http_server
 
 import (
 	contextx "context"
-	"net/http"
-
-	"github.com/urfave/negroni"
-
 	autowire "github.com/alibaba/ioc-golang/autowire"
 	normal "github.com/alibaba/ioc-golang/autowire/normal"
 	util "github.com/alibaba/ioc-golang/autowire/util"
 	"github.com/alibaba/ioc-golang/extension/normal/http_server/ghttp"
+	"github.com/urfave/negroni"
+	"net/http"
 )
 
 func init() {
@@ -88,5 +86,10 @@ func GetImpl(p *HTTPServerConfig) (*Impl, error) {
 	return impl, nil
 }
 func GetImplIOCInterface(p *HTTPServerConfig) (ImplIOCInterface, error) {
-	return GetImpl(p)
+	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl)), p)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(ImplIOCInterface)
+	return impl, nil
 }

--- a/extension/normal/mysql/zz_generated.ioc.go
+++ b/extension/normal/mysql/zz_generated.ioc.go
@@ -6,11 +6,10 @@
 package mysql
 
 import (
-	"gorm.io/gorm"
-
 	"github.com/alibaba/ioc-golang/autowire"
 	normal "github.com/alibaba/ioc-golang/autowire/normal"
 	util "github.com/alibaba/ioc-golang/autowire/util"
+	"gorm.io/gorm"
 )
 
 func init() {
@@ -85,5 +84,10 @@ func GetImpl(p *Config) (*Impl, error) {
 	return impl, nil
 }
 func GetImplIOCInterface(p *Config) (ImplIOCInterface, error) {
-	return GetImpl(p)
+	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl)), p)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(ImplIOCInterface)
+	return impl, nil
 }

--- a/extension/normal/nacos/zz_generated.ioc.go
+++ b/extension/normal/nacos/zz_generated.ioc.go
@@ -6,12 +6,11 @@
 package nacos
 
 import (
-	"github.com/nacos-group/nacos-sdk-go/v2/model"
-	"github.com/nacos-group/nacos-sdk-go/v2/vo"
-
 	autowire "github.com/alibaba/ioc-golang/autowire"
 	normal "github.com/alibaba/ioc-golang/autowire/normal"
 	util "github.com/alibaba/ioc-golang/autowire/util"
+	"github.com/nacos-group/nacos-sdk-go/v2/model"
+	"github.com/nacos-group/nacos-sdk-go/v2/vo"
 )
 
 func init() {
@@ -135,5 +134,10 @@ func GetImpl(p *Config) (*Impl, error) {
 	return impl, nil
 }
 func GetImplIOCInterface(p *Config) (ImplIOCInterface, error) {
-	return GetImpl(p)
+	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl)), p)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(ImplIOCInterface)
+	return impl, nil
 }

--- a/extension/normal/redis/zz_generated.ioc.go
+++ b/extension/normal/redis/zz_generated.ioc.go
@@ -6,13 +6,11 @@
 package redis
 
 import (
-	timex "time"
-
-	go_redisredis "github.com/go-redis/redis"
-
 	autowire "github.com/alibaba/ioc-golang/autowire"
 	normal "github.com/alibaba/ioc-golang/autowire/normal"
 	util "github.com/alibaba/ioc-golang/autowire/util"
+	go_redisredis "github.com/go-redis/redis"
+	timex "time"
 )
 
 func init() {
@@ -76,5 +74,10 @@ func GetImpl(p *Config) (*Impl, error) {
 	return impl, nil
 }
 func GetImplIOCInterface(p *Config) (ImplIOCInterface, error) {
-	return GetImpl(p)
+	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl)), p)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(ImplIOCInterface)
+	return impl, nil
 }

--- a/extension/normal/rocketmq/zz_generated.ioc.go
+++ b/extension/normal/rocketmq/zz_generated.ioc.go
@@ -7,13 +7,11 @@ package rocketmq
 
 import (
 	contextx "context"
-
-	"github.com/apache/rocketmq-client-go/v2/consumer"
-	"github.com/apache/rocketmq-client-go/v2/primitive"
-
 	autowire "github.com/alibaba/ioc-golang/autowire"
 	normal "github.com/alibaba/ioc-golang/autowire/normal"
 	util "github.com/alibaba/ioc-golang/autowire/util"
+	"github.com/apache/rocketmq-client-go/v2/consumer"
+	"github.com/apache/rocketmq-client-go/v2/primitive"
 )
 
 func init() {
@@ -82,5 +80,10 @@ func GetImpl(p *Config) (*Impl, error) {
 	return impl, nil
 }
 func GetImplIOCInterface(p *Config) (ImplIOCInterface, error) {
-	return GetImpl(p)
+	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl)), p)
+	if err != nil {
+		return nil, err
+	}
+	impl := i.(ImplIOCInterface)
+	return impl, nil
 }


### PR DESCRIPTION
1. Add get interface API in generated code, which returns proxy wrapped  struct implementation.
2. Add RPC timeout and error handle logic. related to https://github.com/alibaba/IOC-golang/issues/23
3. Add RPC Proxy debug layer support, related to https://github.com/alibaba/IOC-golang/issues/30 