### PR TITLE
Fix: issue 89, 90

### DIFF
--- a/example/aop/observability/zz_generated.ioc.go
+++ b/example/aop/observability/zz_generated.ioc.go
@@ -84,8 +84,13 @@ type ServiceImpl2IOCInterface interface {
 	GetHelloString(name string) string
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +99,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +110,13 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	return impl, nil
 }
 
+var _serviceImpl1SDID string
+
 func GetServiceImpl1Singleton() (*ServiceImpl1, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(ServiceImpl1)), nil)
+	if _serviceImpl1SDID == "" {
+		_serviceImpl1SDID = util.GetSDIDByStructPtr(new(ServiceImpl1))
+	}
+	i, err := singleton.GetImpl(_serviceImpl1SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +125,10 @@ func GetServiceImpl1Singleton() (*ServiceImpl1, error) {
 }
 
 func GetServiceImpl1IOCInterfaceSingleton() (ServiceImpl1IOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(ServiceImpl1)), nil)
+	if _serviceImpl1SDID == "" {
+		_serviceImpl1SDID = util.GetSDIDByStructPtr(new(ServiceImpl1))
+	}
+	i, err := singleton.GetImplWithProxy(_serviceImpl1SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -120,8 +136,13 @@ func GetServiceImpl1IOCInterfaceSingleton() (ServiceImpl1IOCInterface, error) {
 	return impl, nil
 }
 
+var _serviceImpl2SDID string
+
 func GetServiceImpl2Singleton() (*ServiceImpl2, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(ServiceImpl2)), nil)
+	if _serviceImpl2SDID == "" {
+		_serviceImpl2SDID = util.GetSDIDByStructPtr(new(ServiceImpl2))
+	}
+	i, err := singleton.GetImpl(_serviceImpl2SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +151,10 @@ func GetServiceImpl2Singleton() (*ServiceImpl2, error) {
 }
 
 func GetServiceImpl2IOCInterfaceSingleton() (ServiceImpl2IOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(ServiceImpl2)), nil)
+	if _serviceImpl2SDID == "" {
+		_serviceImpl2SDID = util.GetSDIDByStructPtr(new(ServiceImpl2))
+	}
+	i, err := singleton.GetImplWithProxy(_serviceImpl2SDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/aop/transaction/distributed/client/zz_generated.ioc.go
+++ b/example/aop/transaction/distributed/client/zz_generated.ioc.go
@@ -78,8 +78,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _tradeServiceSDID string
+
 func GetTradeServiceSingleton() (*TradeService, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(TradeService)), nil)
+	if _tradeServiceSDID == "" {
+		_tradeServiceSDID = util.GetSDIDByStructPtr(new(TradeService))
+	}
+	i, err := singleton.GetImpl(_tradeServiceSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +93,10 @@ func GetTradeServiceSingleton() (*TradeService, error) {
 }
 
 func GetTradeServiceIOCInterfaceSingleton() (TradeServiceIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(TradeService)), nil)
+	if _tradeServiceSDID == "" {
+		_tradeServiceSDID = util.GetSDIDByStructPtr(new(TradeService))
+	}
+	i, err := singleton.GetImplWithProxy(_tradeServiceSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +104,13 @@ func GetTradeServiceIOCInterfaceSingleton() (TradeServiceIOCInterface, error) {
 	return impl, nil
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +119,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/aop/transaction/distributed/server/pkg/service/zz_generated.ioc.go
+++ b/example/aop/transaction/distributed/server/pkg/service/zz_generated.ioc.go
@@ -73,8 +73,13 @@ type BankServiceIOCInterface interface {
 	RemoveMoneyRollback(id, num int, errMsg string)
 }
 
+var _bankServiceSDID string
+
 func GetBankServiceRpc() (*BankService, error) {
-	i, err := rpc_service.GetImpl(util.GetSDIDByStructPtr(new(BankService)))
+	if _bankServiceSDID == "" {
+		_bankServiceSDID = util.GetSDIDByStructPtr(new(BankService))
+	}
+	i, err := rpc_service.GetImpl(_bankServiceSDID)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +88,10 @@ func GetBankServiceRpc() (*BankService, error) {
 }
 
 func GetBankServiceIOCInterfaceRpc() (BankServiceIOCInterface, error) {
-	i, err := rpc_service.GetImplWithProxy(util.GetSDIDByStructPtr(new(BankService)))
+	if _bankServiceSDID == "" {
+		_bankServiceSDID = util.GetSDIDByStructPtr(new(BankService))
+	}
+	i, err := rpc_service.GetImplWithProxy(_bankServiceSDID)
 	if err != nil {
 		return nil, err
 	}

--- a/example/aop/transaction/singleton/cmd/zz_generated.ioc.go
+++ b/example/aop/transaction/singleton/cmd/zz_generated.ioc.go
@@ -44,8 +44,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +59,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/aop/transaction/singleton/service/zz_generated.ioc.go
+++ b/example/aop/transaction/singleton/service/zz_generated.ioc.go
@@ -112,8 +112,13 @@ type TradeServiceIOCInterface interface {
 	DoTradeWithTxSuccess(id1, id2, num int) error
 }
 
+var _bankServiceSDID string
+
 func GetBankServiceSingleton() (*BankService, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(BankService)), nil)
+	if _bankServiceSDID == "" {
+		_bankServiceSDID = util.GetSDIDByStructPtr(new(BankService))
+	}
+	i, err := singleton.GetImpl(_bankServiceSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +127,10 @@ func GetBankServiceSingleton() (*BankService, error) {
 }
 
 func GetBankServiceIOCInterfaceSingleton() (BankServiceIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(BankService)), nil)
+	if _bankServiceSDID == "" {
+		_bankServiceSDID = util.GetSDIDByStructPtr(new(BankService))
+	}
+	i, err := singleton.GetImplWithProxy(_bankServiceSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -130,8 +138,13 @@ func GetBankServiceIOCInterfaceSingleton() (BankServiceIOCInterface, error) {
 	return impl, nil
 }
 
+var _tradeServiceSDID string
+
 func GetTradeServiceSingleton() (*TradeService, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(TradeService)), nil)
+	if _tradeServiceSDID == "" {
+		_tradeServiceSDID = util.GetSDIDByStructPtr(new(TradeService))
+	}
+	i, err := singleton.GetImpl(_tradeServiceSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +153,10 @@ func GetTradeServiceSingleton() (*TradeService, error) {
 }
 
 func GetTradeServiceIOCInterfaceSingleton() (TradeServiceIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(TradeService)), nil)
+	if _tradeServiceSDID == "" {
+		_tradeServiceSDID = util.GetSDIDByStructPtr(new(TradeService))
+	}
+	i, err := singleton.GetImplWithProxy(_tradeServiceSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/autowire/autowire_config/cmd/zz_generated.ioc.go
+++ b/example/autowire/autowire_config/cmd/zz_generated.ioc.go
@@ -39,8 +39,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +54,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/autowire/autowire_rpc/client/test/service/zz_generated.ioc.go
+++ b/example/autowire/autowire_rpc/client/test/service/zz_generated.ioc.go
@@ -100,8 +100,13 @@ type SimpleServiceIOCInterface interface {
 	GetUser(name string, age int) (*dto.User, error)
 }
 
+var _complexServiceSDID string
+
 func GetComplexServiceRpc() (*ComplexService, error) {
-	i, err := rpc_service.GetImpl(util.GetSDIDByStructPtr(new(ComplexService)))
+	if _complexServiceSDID == "" {
+		_complexServiceSDID = util.GetSDIDByStructPtr(new(ComplexService))
+	}
+	i, err := rpc_service.GetImpl(_complexServiceSDID)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +115,10 @@ func GetComplexServiceRpc() (*ComplexService, error) {
 }
 
 func GetComplexServiceIOCInterfaceRpc() (ComplexServiceIOCInterface, error) {
-	i, err := rpc_service.GetImplWithProxy(util.GetSDIDByStructPtr(new(ComplexService)))
+	if _complexServiceSDID == "" {
+		_complexServiceSDID = util.GetSDIDByStructPtr(new(ComplexService))
+	}
+	i, err := rpc_service.GetImplWithProxy(_complexServiceSDID)
 	if err != nil {
 		return nil, err
 	}
@@ -118,8 +126,13 @@ func GetComplexServiceIOCInterfaceRpc() (ComplexServiceIOCInterface, error) {
 	return impl, nil
 }
 
+var _simpleServiceSDID string
+
 func GetSimpleServiceRpc() (*SimpleService, error) {
-	i, err := rpc_service.GetImpl(util.GetSDIDByStructPtr(new(SimpleService)))
+	if _simpleServiceSDID == "" {
+		_simpleServiceSDID = util.GetSDIDByStructPtr(new(SimpleService))
+	}
+	i, err := rpc_service.GetImpl(_simpleServiceSDID)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +141,10 @@ func GetSimpleServiceRpc() (*SimpleService, error) {
 }
 
 func GetSimpleServiceIOCInterfaceRpc() (SimpleServiceIOCInterface, error) {
-	i, err := rpc_service.GetImplWithProxy(util.GetSDIDByStructPtr(new(SimpleService)))
+	if _simpleServiceSDID == "" {
+		_simpleServiceSDID = util.GetSDIDByStructPtr(new(SimpleService))
+	}
+	i, err := rpc_service.GetImplWithProxy(_simpleServiceSDID)
 	if err != nil {
 		return nil, err
 	}

--- a/example/autowire/autowire_rpc/client/zz_generated.ioc.go
+++ b/example/autowire/autowire_rpc/client/zz_generated.ioc.go
@@ -38,8 +38,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/autowire/autowire_rpc/server/pkg/service/zz_generated.ioc.go
+++ b/example/autowire/autowire_rpc/server/pkg/service/zz_generated.ioc.go
@@ -40,8 +40,13 @@ type ServiceStructIOCInterface interface {
 	GetUser(name string, age int) (*dto.User, error)
 }
 
+var _serviceStructSDID string
+
 func GetServiceStructRpc() (*ServiceStruct, error) {
-	i, err := rpc_service.GetImpl(util.GetSDIDByStructPtr(new(ServiceStruct)))
+	if _serviceStructSDID == "" {
+		_serviceStructSDID = util.GetSDIDByStructPtr(new(ServiceStruct))
+	}
+	i, err := rpc_service.GetImpl(_serviceStructSDID)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +55,10 @@ func GetServiceStructRpc() (*ServiceStruct, error) {
 }
 
 func GetServiceStructIOCInterfaceRpc() (ServiceStructIOCInterface, error) {
-	i, err := rpc_service.GetImplWithProxy(util.GetSDIDByStructPtr(new(ServiceStruct)))
+	if _serviceStructSDID == "" {
+		_serviceStructSDID = util.GetSDIDByStructPtr(new(ServiceStruct))
+	}
+	i, err := rpc_service.GetImplWithProxy(_serviceStructSDID)
 	if err != nil {
 		return nil, err
 	}

--- a/example/autowire/get_impl_by_api/cmd/zz_generated.ioc.go
+++ b/example/autowire/get_impl_by_api/cmd/zz_generated.ioc.go
@@ -39,8 +39,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +54,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/config_file/activate_profile/zz_generated.ioc.go
+++ b/example/config_file/activate_profile/zz_generated.ioc.go
@@ -38,8 +38,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/config_file/complex_example/zz_generated.ioc.go
+++ b/example/config_file/complex_example/zz_generated.ioc.go
@@ -38,8 +38,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/config_file/default_config_file/zz_generated.ioc.go
+++ b/example/config_file/default_config_file/zz_generated.ioc.go
@@ -38,8 +38,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/config_file/mark_env_variable_in_config_file/zz_generated.ioc.go
+++ b/example/config_file/mark_env_variable_in_config_file/zz_generated.ioc.go
@@ -38,8 +38,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/config_file/mark_nested_value_in_config_file/zz_generated.ioc.go
+++ b/example/config_file/mark_nested_value_in_config_file/zz_generated.ioc.go
@@ -38,8 +38,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/config_file/set_config_file_search_path/zz_generated.ioc.go
+++ b/example/config_file/set_config_file_search_path/zz_generated.ioc.go
@@ -38,8 +38,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/config_file/set_config_file_type/zz_generated.ioc.go
+++ b/example/config_file/set_config_file_type/zz_generated.ioc.go
@@ -38,8 +38,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/config_file/set_config_name/zz_generated.ioc.go
+++ b/example/config_file/set_config_name/zz_generated.ioc.go
@@ -38,8 +38,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/helloworld/zz_generated.ioc.go
+++ b/example/helloworld/zz_generated.ioc.go
@@ -107,8 +107,13 @@ type ServiceStructIOCInterface interface {
 	GetString(name string) string
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +122,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -125,8 +133,13 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	return impl, nil
 }
 
+var _serviceImpl1SDID string
+
 func GetServiceImpl1Singleton() (*ServiceImpl1, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(ServiceImpl1)), nil)
+	if _serviceImpl1SDID == "" {
+		_serviceImpl1SDID = util.GetSDIDByStructPtr(new(ServiceImpl1))
+	}
+	i, err := singleton.GetImpl(_serviceImpl1SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +148,10 @@ func GetServiceImpl1Singleton() (*ServiceImpl1, error) {
 }
 
 func GetServiceImpl1IOCInterfaceSingleton() (ServiceImpl1IOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(ServiceImpl1)), nil)
+	if _serviceImpl1SDID == "" {
+		_serviceImpl1SDID = util.GetSDIDByStructPtr(new(ServiceImpl1))
+	}
+	i, err := singleton.GetImplWithProxy(_serviceImpl1SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -143,8 +159,13 @@ func GetServiceImpl1IOCInterfaceSingleton() (ServiceImpl1IOCInterface, error) {
 	return impl, nil
 }
 
+var _serviceImpl2SDID string
+
 func GetServiceImpl2Singleton() (*ServiceImpl2, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(ServiceImpl2)), nil)
+	if _serviceImpl2SDID == "" {
+		_serviceImpl2SDID = util.GetSDIDByStructPtr(new(ServiceImpl2))
+	}
+	i, err := singleton.GetImpl(_serviceImpl2SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +174,10 @@ func GetServiceImpl2Singleton() (*ServiceImpl2, error) {
 }
 
 func GetServiceImpl2IOCInterfaceSingleton() (ServiceImpl2IOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(ServiceImpl2)), nil)
+	if _serviceImpl2SDID == "" {
+		_serviceImpl2SDID = util.GetSDIDByStructPtr(new(ServiceImpl2))
+	}
+	i, err := singleton.GetImplWithProxy(_serviceImpl2SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -161,8 +185,13 @@ func GetServiceImpl2IOCInterfaceSingleton() (ServiceImpl2IOCInterface, error) {
 	return impl, nil
 }
 
+var _serviceStructSDID string
+
 func GetServiceStructSingleton() (*ServiceStruct, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(ServiceStruct)), nil)
+	if _serviceStructSDID == "" {
+		_serviceStructSDID = util.GetSDIDByStructPtr(new(ServiceStruct))
+	}
+	i, err := singleton.GetImpl(_serviceStructSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +200,10 @@ func GetServiceStructSingleton() (*ServiceStruct, error) {
 }
 
 func GetServiceStructIOCInterfaceSingleton() (ServiceStructIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(ServiceStruct)), nil)
+	if _serviceStructSDID == "" {
+		_serviceStructSDID = util.GetSDIDByStructPtr(new(ServiceStruct))
+	}
+	i, err := singleton.GetImplWithProxy(_serviceStructSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/third_party/autowire/grpc/cmd/service1/zz_generated.ioc.go
+++ b/example/third_party/autowire/grpc/cmd/service1/zz_generated.ioc.go
@@ -38,8 +38,13 @@ type Impl1IOCInterface interface {
 	Hello(req string) string
 }
 
+var _impl1SDID string
+
 func GetImpl1Singleton() (*Impl1, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(Impl1)), nil)
+	if _impl1SDID == "" {
+		_impl1SDID = util.GetSDIDByStructPtr(new(Impl1))
+	}
+	i, err := singleton.GetImpl(_impl1SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,10 @@ func GetImpl1Singleton() (*Impl1, error) {
 }
 
 func GetImpl1IOCInterfaceSingleton() (Impl1IOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl1)), nil)
+	if _impl1SDID == "" {
+		_impl1SDID = util.GetSDIDByStructPtr(new(Impl1))
+	}
+	i, err := singleton.GetImplWithProxy(_impl1SDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/third_party/autowire/grpc/cmd/service2/zz_generated.ioc.go
+++ b/example/third_party/autowire/grpc/cmd/service2/zz_generated.ioc.go
@@ -61,8 +61,13 @@ type Impl2IOCInterface interface {
 	Hello(name string) string
 }
 
+var _impl1SDID string
+
 func GetImpl1Singleton() (*Impl1, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(Impl1)), nil)
+	if _impl1SDID == "" {
+		_impl1SDID = util.GetSDIDByStructPtr(new(Impl1))
+	}
+	i, err := singleton.GetImpl(_impl1SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +76,10 @@ func GetImpl1Singleton() (*Impl1, error) {
 }
 
 func GetImpl1IOCInterfaceSingleton() (Impl1IOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl1)), nil)
+	if _impl1SDID == "" {
+		_impl1SDID = util.GetSDIDByStructPtr(new(Impl1))
+	}
+	i, err := singleton.GetImplWithProxy(_impl1SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +87,13 @@ func GetImpl1IOCInterfaceSingleton() (Impl1IOCInterface, error) {
 	return impl, nil
 }
 
+var _impl2SDID string
+
 func GetImpl2Singleton() (*Impl2, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(Impl2)), nil)
+	if _impl2SDID == "" {
+		_impl2SDID = util.GetSDIDByStructPtr(new(Impl2))
+	}
+	i, err := singleton.GetImpl(_impl2SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +102,10 @@ func GetImpl2Singleton() (*Impl2, error) {
 }
 
 func GetImpl2IOCInterfaceSingleton() (Impl2IOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl2)), nil)
+	if _impl2SDID == "" {
+		_impl2SDID = util.GetSDIDByStructPtr(new(Impl2))
+	}
+	i, err := singleton.GetImplWithProxy(_impl2SDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/third_party/autowire/grpc/cmd/struct1/zz_generated.ioc.go
+++ b/example/third_party/autowire/grpc/cmd/struct1/zz_generated.ioc.go
@@ -38,8 +38,13 @@ type Struct1IOCInterface interface {
 	Hello(name string) string
 }
 
+var _struct1SDID string
+
 func GetStruct1Singleton() (*Struct1, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(Struct1)), nil)
+	if _struct1SDID == "" {
+		_struct1SDID = util.GetSDIDByStructPtr(new(Struct1))
+	}
+	i, err := singleton.GetImpl(_struct1SDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +53,10 @@ func GetStruct1Singleton() (*Struct1, error) {
 }
 
 func GetStruct1IOCInterfaceSingleton() (Struct1IOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Struct1)), nil)
+	if _struct1SDID == "" {
+		_struct1SDID = util.GetSDIDByStructPtr(new(Struct1))
+	}
+	i, err := singleton.GetImplWithProxy(_struct1SDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/third_party/autowire/grpc/cmd/zz_generated.ioc.go
+++ b/example/third_party/autowire/grpc/cmd/zz_generated.ioc.go
@@ -39,8 +39,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +54,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/third_party/db/gorm/cmd/zz_generated.ioc.go
+++ b/example/third_party/db/gorm/cmd/zz_generated.ioc.go
@@ -39,8 +39,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton() (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +54,10 @@ func GetAppSingleton() (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), nil)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/example/third_party/registry/nacos/cmd/zz_generated.ioc.go
+++ b/example/third_party/registry/nacos/cmd/zz_generated.ioc.go
@@ -51,8 +51,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton(p *Param) (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), p)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +66,10 @@ func GetAppSingleton(p *Param) (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton(p *Param) (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), p)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, p)
 	if err != nil {
 		return nil, err
 	}

--- a/example/third_party/state/redis/cmd/zz_generated.ioc.go
+++ b/example/third_party/state/redis/cmd/zz_generated.ioc.go
@@ -51,8 +51,13 @@ type AppIOCInterface interface {
 	Run()
 }
 
+var _appSDID string
+
 func GetAppSingleton(p *Param) (*App, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(App)), p)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImpl(_appSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +66,10 @@ func GetAppSingleton(p *Param) (*App, error) {
 }
 
 func GetAppIOCInterfaceSingleton(p *Param) (AppIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(App)), p)
+	if _appSDID == "" {
+		_appSDID = util.GetSDIDByStructPtr(new(App))
+	}
+	i, err := singleton.GetImplWithProxy(_appSDID, p)
 	if err != nil {
 		return nil, err
 	}

--- a/extension/autowire/rpc/protocol/protocol_impl/zz_generated.ioc.go
+++ b/extension/autowire/rpc/protocol/protocol_impl/zz_generated.ioc.go
@@ -57,8 +57,13 @@ type IOCProtocolIOCInterface interface {
 	Export(invoker protocol.Invoker) protocol.Exporter
 }
 
+var _iOCProtocolSDID string
+
 func GetIOCProtocol(p *Param) (*IOCProtocol, error) {
-	i, err := normal.GetImpl(util.GetSDIDByStructPtr(new(IOCProtocol)), p)
+	if _iOCProtocolSDID == "" {
+		_iOCProtocolSDID = util.GetSDIDByStructPtr(new(IOCProtocol))
+	}
+	i, err := normal.GetImpl(_iOCProtocolSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +72,10 @@ func GetIOCProtocol(p *Param) (*IOCProtocol, error) {
 }
 
 func GetIOCProtocolIOCInterface(p *Param) (IOCProtocolIOCInterface, error) {
-	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(IOCProtocol)), p)
+	if _iOCProtocolSDID == "" {
+		_iOCProtocolSDID = util.GetSDIDByStructPtr(new(IOCProtocol))
+	}
+	i, err := normal.GetImplWithProxy(_iOCProtocolSDID, p)
 	if err != nil {
 		return nil, err
 	}

--- a/extension/config/zz_generated.ioc.go
+++ b/extension/config/zz_generated.ioc.go
@@ -253,3 +253,10 @@ type ConfigStringIOCInterface interface {
 	Value() string
 	New(impl *ConfigString) (*ConfigString, error)
 }
+
+var _configFloat64SDID string
+var _configInt64SDID string
+var _configIntSDID string
+var _configMapSDID string
+var _configSliceSDID string
+var _configStringSDID string

--- a/extension/config_center/nacos/zz_generated.ioc.go
+++ b/extension/config_center/nacos/zz_generated.ioc.go
@@ -84,8 +84,13 @@ type ConfigClientIOCInterface interface {
 	SearchConfig(param vo.SearchConfigParm) (*model.ConfigPage, error)
 }
 
+var _configClientSDID string
+
 func GetConfigClient(p *Param) (*ConfigClient, error) {
-	i, err := normal.GetImpl(util.GetSDIDByStructPtr(new(ConfigClient)), p)
+	if _configClientSDID == "" {
+		_configClientSDID = util.GetSDIDByStructPtr(new(ConfigClient))
+	}
+	i, err := normal.GetImpl(_configClientSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +99,10 @@ func GetConfigClient(p *Param) (*ConfigClient, error) {
 }
 
 func GetConfigClientIOCInterface(p *Param) (ConfigClientIOCInterface, error) {
-	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(ConfigClient)), p)
+	if _configClientSDID == "" {
+		_configClientSDID = util.GetSDIDByStructPtr(new(ConfigClient))
+	}
+	i, err := normal.GetImplWithProxy(_configClientSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +110,13 @@ func GetConfigClientIOCInterface(p *Param) (ConfigClientIOCInterface, error) {
 	return impl, nil
 }
 
+var _configClientSDID string
+
 func GetConfigClientSingleton(p *Param) (*ConfigClient, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(ConfigClient)), p)
+	if _configClientSDID == "" {
+		_configClientSDID = util.GetSDIDByStructPtr(new(ConfigClient))
+	}
+	i, err := singleton.GetImpl(_configClientSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +125,10 @@ func GetConfigClientSingleton(p *Param) (*ConfigClient, error) {
 }
 
 func GetConfigClientIOCInterfaceSingleton(p *Param) (ConfigClientIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(ConfigClient)), p)
+	if _configClientSDID == "" {
+		_configClientSDID = util.GetSDIDByStructPtr(new(ConfigClient))
+	}
+	i, err := singleton.GetImplWithProxy(_configClientSDID, p)
 	if err != nil {
 		return nil, err
 	}

--- a/extension/config_center/nacos/zz_generated.ioc.go
+++ b/extension/config_center/nacos/zz_generated.ioc.go
@@ -110,8 +110,6 @@ func GetConfigClientIOCInterface(p *Param) (ConfigClientIOCInterface, error) {
 	return impl, nil
 }
 
-var _configClientSDID string
-
 func GetConfigClientSingleton(p *Param) (*ConfigClient, error) {
 	if _configClientSDID == "" {
 		_configClientSDID = util.GetSDIDByStructPtr(new(ConfigClient))

--- a/extension/db/gorm/zz_generated.ioc.go
+++ b/extension/db/gorm/zz_generated.ioc.go
@@ -473,8 +473,6 @@ func GetGORMDBIOCInterface(p *Param) (GORMDBIOCInterface, error) {
 	return impl, nil
 }
 
-var _gORMDBSDID string
-
 func GetGORMDBSingleton(p *Param) (*GORMDB, error) {
 	if _gORMDBSDID == "" {
 		_gORMDBSDID = util.GetSDIDByStructPtr(new(GORMDB))

--- a/extension/db/gorm/zz_generated.ioc.go
+++ b/extension/db/gorm/zz_generated.ioc.go
@@ -447,8 +447,13 @@ type GORMDBIOCInterface interface {
 	Association(column string) *gorm_iogormx.Association
 }
 
+var _gORMDBSDID string
+
 func GetGORMDB(p *Param) (*GORMDB, error) {
-	i, err := normal.GetImpl(util.GetSDIDByStructPtr(new(GORMDB)), p)
+	if _gORMDBSDID == "" {
+		_gORMDBSDID = util.GetSDIDByStructPtr(new(GORMDB))
+	}
+	i, err := normal.GetImpl(_gORMDBSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -457,7 +462,10 @@ func GetGORMDB(p *Param) (*GORMDB, error) {
 }
 
 func GetGORMDBIOCInterface(p *Param) (GORMDBIOCInterface, error) {
-	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(GORMDB)), p)
+	if _gORMDBSDID == "" {
+		_gORMDBSDID = util.GetSDIDByStructPtr(new(GORMDB))
+	}
+	i, err := normal.GetImplWithProxy(_gORMDBSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -465,8 +473,13 @@ func GetGORMDBIOCInterface(p *Param) (GORMDBIOCInterface, error) {
 	return impl, nil
 }
 
+var _gORMDBSDID string
+
 func GetGORMDBSingleton(p *Param) (*GORMDB, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(GORMDB)), p)
+	if _gORMDBSDID == "" {
+		_gORMDBSDID = util.GetSDIDByStructPtr(new(GORMDB))
+	}
+	i, err := singleton.GetImpl(_gORMDBSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -475,7 +488,10 @@ func GetGORMDBSingleton(p *Param) (*GORMDB, error) {
 }
 
 func GetGORMDBIOCInterfaceSingleton(p *Param) (GORMDBIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(GORMDB)), p)
+	if _gORMDBSDID == "" {
+		_gORMDBSDID = util.GetSDIDByStructPtr(new(GORMDB))
+	}
+	i, err := singleton.GetImplWithProxy(_gORMDBSDID, p)
 	if err != nil {
 		return nil, err
 	}

--- a/extension/pubsub/rocketmq/zz_generated.ioc.go
+++ b/extension/pubsub/rocketmq/zz_generated.ioc.go
@@ -80,8 +80,13 @@ type ImplIOCInterface interface {
 	SendOneWay(ctx contextx.Context, mq ...*primitive.Message) error
 }
 
+var _implSDID string
+
 func GetImpl(p *Param) (*Impl, error) {
-	i, err := normal.GetImpl(util.GetSDIDByStructPtr(new(Impl)), p)
+	if _implSDID == "" {
+		_implSDID = util.GetSDIDByStructPtr(new(Impl))
+	}
+	i, err := normal.GetImpl(_implSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +95,10 @@ func GetImpl(p *Param) (*Impl, error) {
 }
 
 func GetImplIOCInterface(p *Param) (ImplIOCInterface, error) {
-	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl)), p)
+	if _implSDID == "" {
+		_implSDID = util.GetSDIDByStructPtr(new(Impl))
+	}
+	i, err := normal.GetImplWithProxy(_implSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +106,13 @@ func GetImplIOCInterface(p *Param) (ImplIOCInterface, error) {
 	return impl, nil
 }
 
+var _implSDID string
+
 func GetImplSingleton(p *Param) (*Impl, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(Impl)), p)
+	if _implSDID == "" {
+		_implSDID = util.GetSDIDByStructPtr(new(Impl))
+	}
+	i, err := singleton.GetImpl(_implSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +121,10 @@ func GetImplSingleton(p *Param) (*Impl, error) {
 }
 
 func GetImplIOCInterfaceSingleton(p *Param) (ImplIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Impl)), p)
+	if _implSDID == "" {
+		_implSDID = util.GetSDIDByStructPtr(new(Impl))
+	}
+	i, err := singleton.GetImplWithProxy(_implSDID, p)
 	if err != nil {
 		return nil, err
 	}

--- a/extension/pubsub/rocketmq/zz_generated.ioc.go
+++ b/extension/pubsub/rocketmq/zz_generated.ioc.go
@@ -106,8 +106,6 @@ func GetImplIOCInterface(p *Param) (ImplIOCInterface, error) {
 	return impl, nil
 }
 
-var _implSDID string
-
 func GetImplSingleton(p *Param) (*Impl, error) {
 	if _implSDID == "" {
 		_implSDID = util.GetSDIDByStructPtr(new(Impl))

--- a/extension/registry/nacos/zz_generated.ioc.go
+++ b/extension/registry/nacos/zz_generated.ioc.go
@@ -134,8 +134,6 @@ func GetNamingClientIOCInterface(p *Param) (NamingClientIOCInterface, error) {
 	return impl, nil
 }
 
-var _namingClientSDID string
-
 func GetNamingClientSingleton(p *Param) (*NamingClient, error) {
 	if _namingClientSDID == "" {
 		_namingClientSDID = util.GetSDIDByStructPtr(new(NamingClient))

--- a/extension/registry/nacos/zz_generated.ioc.go
+++ b/extension/registry/nacos/zz_generated.ioc.go
@@ -108,8 +108,13 @@ type NamingClientIOCInterface interface {
 	Unsubscribe(param *vo.SubscribeParam) (err error)
 }
 
+var _namingClientSDID string
+
 func GetNamingClient(p *Param) (*NamingClient, error) {
-	i, err := normal.GetImpl(util.GetSDIDByStructPtr(new(NamingClient)), p)
+	if _namingClientSDID == "" {
+		_namingClientSDID = util.GetSDIDByStructPtr(new(NamingClient))
+	}
+	i, err := normal.GetImpl(_namingClientSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +123,10 @@ func GetNamingClient(p *Param) (*NamingClient, error) {
 }
 
 func GetNamingClientIOCInterface(p *Param) (NamingClientIOCInterface, error) {
-	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(NamingClient)), p)
+	if _namingClientSDID == "" {
+		_namingClientSDID = util.GetSDIDByStructPtr(new(NamingClient))
+	}
+	i, err := normal.GetImplWithProxy(_namingClientSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -126,8 +134,13 @@ func GetNamingClientIOCInterface(p *Param) (NamingClientIOCInterface, error) {
 	return impl, nil
 }
 
+var _namingClientSDID string
+
 func GetNamingClientSingleton(p *Param) (*NamingClient, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(NamingClient)), p)
+	if _namingClientSDID == "" {
+		_namingClientSDID = util.GetSDIDByStructPtr(new(NamingClient))
+	}
+	i, err := singleton.GetImpl(_namingClientSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +149,10 @@ func GetNamingClientSingleton(p *Param) (*NamingClient, error) {
 }
 
 func GetNamingClientIOCInterfaceSingleton(p *Param) (NamingClientIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(NamingClient)), p)
+	if _namingClientSDID == "" {
+		_namingClientSDID = util.GetSDIDByStructPtr(new(NamingClient))
+	}
+	i, err := singleton.GetImplWithProxy(_namingClientSDID, p)
 	if err != nil {
 		return nil, err
 	}

--- a/extension/state/redis/zz_generated.ioc.go
+++ b/extension/state/redis/zz_generated.ioc.go
@@ -1532,8 +1532,13 @@ type RedisIOCInterface interface {
 	PSubscribe(channels ...string) *go_redisredis.PubSub
 }
 
+var _redisSDID string
+
 func GetRedis(p *Param) (*Redis, error) {
-	i, err := normal.GetImpl(util.GetSDIDByStructPtr(new(Redis)), p)
+	if _redisSDID == "" {
+		_redisSDID = util.GetSDIDByStructPtr(new(Redis))
+	}
+	i, err := normal.GetImpl(_redisSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -1542,7 +1547,10 @@ func GetRedis(p *Param) (*Redis, error) {
 }
 
 func GetRedisIOCInterface(p *Param) (RedisIOCInterface, error) {
-	i, err := normal.GetImplWithProxy(util.GetSDIDByStructPtr(new(Redis)), p)
+	if _redisSDID == "" {
+		_redisSDID = util.GetSDIDByStructPtr(new(Redis))
+	}
+	i, err := normal.GetImplWithProxy(_redisSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -1550,8 +1558,13 @@ func GetRedisIOCInterface(p *Param) (RedisIOCInterface, error) {
 	return impl, nil
 }
 
+var _redisSDID string
+
 func GetRedisSingleton(p *Param) (*Redis, error) {
-	i, err := singleton.GetImpl(util.GetSDIDByStructPtr(new(Redis)), p)
+	if _redisSDID == "" {
+		_redisSDID = util.GetSDIDByStructPtr(new(Redis))
+	}
+	i, err := singleton.GetImpl(_redisSDID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -1560,7 +1573,10 @@ func GetRedisSingleton(p *Param) (*Redis, error) {
 }
 
 func GetRedisIOCInterfaceSingleton(p *Param) (RedisIOCInterface, error) {
-	i, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(new(Redis)), p)
+	if _redisSDID == "" {
+		_redisSDID = util.GetSDIDByStructPtr(new(Redis))
+	}
+	i, err := singleton.GetImplWithProxy(_redisSDID, p)
 	if err != nil {
 		return nil, err
 	}

--- a/extension/state/redis/zz_generated.ioc.go
+++ b/extension/state/redis/zz_generated.ioc.go
@@ -1558,8 +1558,6 @@ func GetRedisIOCInterface(p *Param) (RedisIOCInterface, error) {
 	return impl, nil
 }
 
-var _redisSDID string
-
 func GetRedisSingleton(p *Param) (*Redis, error) {
 	if _redisSDID == "" {
 		_redisSDID = util.GetSDIDByStructPtr(new(Redis))

--- a/iocli/gen/inject/gen.go
+++ b/iocli/gen/inject/gen.go
@@ -41,6 +41,7 @@ var (
 	iocGolangAutowireParamLoaderMarker   = markers.Must(markers.MakeDefinition("ioc:autowire:paramLoader", markers.DescribesType, ""))
 	iocGolangAutowireConstructFuncMarker = markers.Must(markers.MakeDefinition("ioc:autowire:constructFunc", markers.DescribesType, ""))
 	iocGolangAutowireAliasMarker         = markers.Must(markers.MakeDefinition("ioc:autowire:alias", markers.DescribesType, ""))
+	iocGolangAutowireProxyMarker         = markers.Must(markers.MakeDefinition("ioc:autowire:proxy", markers.DescribesType, false))
 
 	iocGolangTransactionFuncMarker = markers.Must(markers.MakeDefinition("ioc:tx:func", markers.DescribesType, ""))
 )
@@ -68,6 +69,7 @@ func (Generator) RegisterMarkers(into *markers.Registry) error {
 		iocGolangAutowireBaseTypeMarker,
 		iocGolangAutowireAliasMarker, // alias
 		iocGolangTransactionFuncMarker,
+		iocGolangAutowireProxyMarker,
 	); err != nil {
 		return err
 	}

--- a/iocli/gen/inject/register.go
+++ b/iocli/gen/inject/register.go
@@ -365,6 +365,7 @@ func (c *copyMethodMaker) GenerateMethodsFor(ctx *genall.GenerationContext, root
 	// gen get method and get interface method
 	for _, g := range getMethodGenerateCtxs {
 		sdidStrName := fmt.Sprintf("_%sSDID", toFirstCharLower(g.structName))
+		c.Linef("var %s string", sdidStrName)
 		for _, autowireAliasPair := range g.autowireTypeAliasPairs {
 			if autowireAliasPair.autowireType == "config" {
 				continue
@@ -376,7 +377,6 @@ func (c *copyMethodMaker) GenerateMethodsFor(ctx *genall.GenerationContext, root
 
 			if g.paramTypeName != "" && autowireAliasPair.autowireType != "rpc" {
 				utilAlias := c.NeedImport("github.com/alibaba/ioc-golang/autowire/util")
-				c.Linef("var %s string", sdidStrName)
 				c.Linef(`func Get%s%s(p *%s)(*%s, error){
 			if %s == ""{
 				%s = %s.GetSDIDByStructPtr(new(%s))
@@ -406,7 +406,6 @@ func (c *copyMethodMaker) GenerateMethodsFor(ctx *genall.GenerationContext, root
 				c.Line("")
 			} else {
 				utilAlias := c.NeedImport("github.com/alibaba/ioc-golang/autowire/util")
-				c.Linef("var %s string", sdidStrName)
 				c.Linef(`func Get%s%s()(*%s, error){`, g.structName, getterSuffix, g.structName)
 				c.Linef(`if %s == ""{
 					%s = %s.GetSDIDByStructPtr(new(%s))

--- a/iocli/go.mod
+++ b/iocli/go.mod
@@ -3,7 +3,7 @@ module github.com/alibaba/ioc-golang/iocli
 go 1.17
 
 require (
-	github.com/alibaba/ioc-golang/extension v0.0.0-20220710133443-0d226913437e
+	github.com/alibaba/ioc-golang/extension v0.0.0-20220710160554-a0fc1c8fd81b
 	github.com/gobuffalo/packr/v2 v2.8.3
 	github.com/spf13/cobra v1.5.0
 	sigs.k8s.io/controller-tools v0.9.0

--- a/iocli/go.sum
+++ b/iocli/go.sum
@@ -43,8 +43,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/alibaba/ioc-golang/extension v0.0.0-20220710133443-0d226913437e h1:CJt9Wpx5NmBqPH6yOyZcgCFWxLm/Moz1dqekQsJphX8=
-github.com/alibaba/ioc-golang/extension v0.0.0-20220710133443-0d226913437e/go.mod h1:dz2cOIWsQYjGJmSoS+/5CO0dCbukvoMJDDS2Mtm2/ys=
+github.com/alibaba/ioc-golang/extension v0.0.0-20220710160554-a0fc1c8fd81b h1:fbLwY5YH9bQfsQ0hmOrQYiEndZbFAM19giTPTq7RryQ=
+github.com/alibaba/ioc-golang/extension v0.0.0-20220710160554-a0fc1c8fd81b/go.mod h1:dz2cOIWsQYjGJmSoS+/5CO0dCbukvoMJDDS2Mtm2/ys=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
Fix https://github.com/alibaba/IOC-golang/issues/90 , add `+ioc:autowire:proxy=false` annotation to disable generation of proxy struct and related APIs.

Fix https://github.com/alibaba/IOC-golang/issues/89, add _XXXSDID string in generated codes to cache struct describer ID string and  enhancement getter APIs. 