### PR TITLE
ftr: add params and returnValues in tracing span

### DIFF
--- a/aop/common/util.go
+++ b/aop/common/util.go
@@ -16,6 +16,7 @@
 package common
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -29,6 +30,11 @@ func GetMethodUniqueKey(interfaceImplId, methodName string) string {
 func ParseSDIDAndMethodFromUniqueKey(uniqueKey string) (string, string) {
 	splitedUniqueKey := strings.Split(uniqueKey, "-")
 	return strings.Join(splitedUniqueKey[:len(splitedUniqueKey)-1], "-"), splitedUniqueKey[len(splitedUniqueKey)-1]
+}
+
+func ReflectValues2String(values []reflect.Value, maxDepth int) string {
+	strs := ReflectValues2Strings(values, maxDepth)
+	return fmt.Sprintf("%+v", strs)
 }
 
 func ReflectValues2Strings(values []reflect.Value, maxDepth int) []string {

--- a/extension/aop/trace/aop.go
+++ b/extension/aop/trace/aop.go
@@ -42,6 +42,9 @@ func init() {
 			} else {
 				setCollectorAddress(traceConfig.CollectorAddress)
 			}
+			if traceConfig.ValueDepth != 0 {
+				valueDepth = traceConfig.ValueDepth
+			}
 		},
 	})
 }

--- a/extension/aop/trace/cli/trace.go
+++ b/extension/aop/trace/cli/trace.go
@@ -103,7 +103,7 @@ var trace = &cobra.Command{
 				}
 			}
 			if data := msg.ThriftSerializedSpans; pushToAddr != "" && data != nil && len(data) > 0 {
-				// 1. push to collector
+				// try to push spans to collector
 				body := bytes.NewBuffer(data)
 				req, err := http.NewRequest("POST", jaegerCollectorEndpoint, body)
 				if err != nil {
@@ -112,6 +112,7 @@ var trace = &cobra.Command{
 				}
 				req.Header.Set("Content-Type", "application/x-thrift")
 				go func() {
+					// async post to collector
 					resp, err := http.DefaultClient.Do(req)
 					if err != nil {
 						color.Red("Http request with url %s failed with error %s, ", jaegerCollectorEndpoint, err)

--- a/extension/aop/trace/cli/trace.go
+++ b/extension/aop/trace/cli/trace.go
@@ -19,7 +19,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
+	"io/ioutil"
 	"net/http"
+	"os"
+	"os/signal"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -33,7 +37,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func getTraceServiceClent(addr string) tracePB.TraceServiceClient {
+func getTraceServiceClient(addr string) tracePB.TraceServiceClient {
 	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		panic(err)
@@ -53,7 +57,7 @@ var trace = &cobra.Command{
 			method = args[1]
 		}
 		debugServerAddr := fmt.Sprintf("%s:%d", debugHost, debugPort)
-		debugServiceClient := getTraceServiceClent(debugServerAddr)
+		debugServiceClient := getTraceServiceClient(debugServerAddr)
 		color.Cyan("iocli trace started, try to connect to debug server at %s", debugServerAddr)
 		client, err := debugServiceClient.Trace(context.Background(), &tracePB.TraceRequest{
 			Sdid:                   sdid,
@@ -71,10 +75,24 @@ var trace = &cobra.Command{
 			color.Cyan("try to push span batch data to %s", pushToAddr)
 		}
 
+		cacheData := bytes.Buffer{}
+		if storeToFile != "" {
+			color.Cyan("Spans data is collecting, in order to save to %s", storeToFile)
+			go func() {
+				signals := make(chan os.Signal, 1)
+				signal.Notify(signals, os.Interrupt, os.Kill)
+				select {
+				case <-signals:
+					writeSpans(cacheData)
+				}
+			}()
+		}
+
 		for {
 			msg, err := client.Recv()
 			if err != nil {
 				color.Red(err.Error())
+				writeSpans(cacheData)
 				return
 			}
 			for _, t := range msg.Traces {
@@ -85,6 +103,7 @@ var trace = &cobra.Command{
 				}
 			}
 			if data := msg.ThriftSerializedSpans; pushToAddr != "" && data != nil && len(data) > 0 {
+				// 1. push to collector
 				body := bytes.NewBuffer(data)
 				req, err := http.NewRequest("POST", jaegerCollectorEndpoint, body)
 				if err != nil {
@@ -103,15 +122,25 @@ var trace = &cobra.Command{
 						return
 					}
 				}()
+				cacheData.Write(data)
 			}
 		}
 	},
 }
 
+func writeSpans(cacheData bytes.Buffer) {
+	if err := ioutil.WriteFile(storeToFile, cacheData.Bytes(), fs.ModePerm); err != nil {
+		color.Red("Write cached spans data to %s failed, error is %s", storeToFile, err.Error())
+		os.Exit(1)
+	}
+	color.Cyan("Write spans to %s finished", storeToFile)
+}
+
 var (
-	debugHost  string
-	debugPort  int
-	pushToAddr string
+	debugHost   string
+	debugPort   int
+	pushToAddr  string
+	storeToFile string
 )
 
 func init() {
@@ -119,4 +148,5 @@ func init() {
 	trace.Flags().IntVarP(&debugPort, "port", "p", 1999, "debug port")
 	trace.Flags().StringVar(&debugHost, "host", "127.0.0.1", "debug host")
 	trace.Flags().StringVar(&pushToAddr, "pushAddr", "", "push to jaeger collector address")
+	trace.Flags().StringVar(&storeToFile, "store", "", "spans data store to file name")
 }

--- a/extension/aop/trace/common/span_key.go
+++ b/extension/aop/trace/common/span_key.go
@@ -1,7 +1,7 @@
 package common
 
 const (
-	SpanParamKey             = "param"
+	SpanParamsKey            = "params"
 	SpanReturnValuesKey      = "returnValues"
 	DefaultRecordValuesDepth = 5
 )

--- a/extension/aop/trace/common/span_key.go
+++ b/extension/aop/trace/common/span_key.go
@@ -1,0 +1,7 @@
+package common
+
+const (
+	SpanParamKey             = "param"
+	SpanReturnValuesKey      = "returnValues"
+	DefaultRecordValuesDepth = 5
+)

--- a/extension/aop/trace/config.go
+++ b/extension/aop/trace/config.go
@@ -17,4 +17,5 @@ package trace
 
 type TraceConfig struct {
 	CollectorAddress string `yaml:"collector-address"`
+	ValueDepth       int    `yaml:"value-depth"`
 }

--- a/extension/aop/trace/goroutine.go
+++ b/extension/aop/trace/goroutine.go
@@ -36,7 +36,7 @@ func (g *goRoutineTraceInterceptor) BeforeInvoke(ctx *aop.InvocationContext) {
 	if val, ok := g.tracingGrIDMap.Load(ctx.GrID); ok {
 		// this goRoutine is watched, add new child node
 		currentSpan := val.(*goRoutineTracingContext).getTrace().addChildSpan(ctx.MethodFullName)
-		currentSpan.span.LogFields(log.String(traceCommon.SpanParamKey, common.ReflectValues2String(ctx.Params, valueDepth)))
+		currentSpan.span.LogFields(log.String(traceCommon.SpanParamsKey, common.ReflectValues2String(ctx.Params, valueDepth)))
 		return
 	}
 }

--- a/extension/aop/trace/goroutine.go
+++ b/extension/aop/trace/goroutine.go
@@ -16,13 +16,15 @@
 package trace
 
 import (
-	"fmt"
 	"sync"
+
+	"github.com/opentracing/opentracing-go/log"
 
 	"github.com/petermattis/goid"
 
 	"github.com/alibaba/ioc-golang/aop"
 	"github.com/alibaba/ioc-golang/aop/common"
+	traceCommon "github.com/alibaba/ioc-golang/extension/aop/trace/common"
 )
 
 type goRoutineTraceInterceptor struct {
@@ -33,7 +35,8 @@ func (g *goRoutineTraceInterceptor) BeforeInvoke(ctx *aop.InvocationContext) {
 	// 1. if current goroutine is watched?
 	if val, ok := g.tracingGrIDMap.Load(ctx.GrID); ok {
 		// this goRoutine is watched, add new child node
-		val.(*goRoutineTracingContext).getTrace().addChildSpan(ctx.MethodFullName)
+		currentSpan := val.(*goRoutineTracingContext).getTrace().addChildSpan(ctx.MethodFullName)
+		currentSpan.span.LogFields(log.String(traceCommon.SpanParamKey, common.ReflectValues2String(ctx.Params, valueDepth)))
 		return
 	}
 }
@@ -43,16 +46,13 @@ func (g *goRoutineTraceInterceptor) AfterInvoke(ctx *aop.InvocationContext) {
 	if val, ok := g.tracingGrIDMap.Load(ctx.GrID); ok {
 		// this goRoutine is watched, return span
 		traceCtx := val.(*goRoutineTracingContext)
-		currentSpan := traceCtx.getTrace().currentSpan
+		currentSpan := traceCtx.getTrace().currentSpan.span
 		traceCtx.getTrace().returnSpan()
+		currentSpan.LogFields(log.String(traceCommon.SpanReturnValuesKey, common.ReflectValues2String(ctx.ReturnValues, valueDepth)))
 
 		// calculate level
 		if common.TraceLevel(traceCtx.getTrace().entranceMethod) == 0 {
 			// tracing finished
-			currentSpan.span.Context().ForeachBaggageItem(func(k, v string) bool {
-				fmt.Println(k, v)
-				return true
-			})
 			g.tracingGrIDMap.Delete(ctx.GrID)
 		}
 	}

--- a/extension/aop/trace/interceptor.go
+++ b/extension/aop/trace/interceptor.go
@@ -18,6 +18,8 @@ package trace
 import (
 	"github.com/opentracing/opentracing-go"
 
+	traceCommon "github.com/alibaba/ioc-golang/extension/aop/trace/common"
+
 	"github.com/alibaba/ioc-golang/aop"
 )
 
@@ -91,6 +93,8 @@ func (m *methodTraceInterceptor) GetCurrentSpan() opentracing.Span {
 }
 
 var methodTraceInterceptorSingleton *methodTraceInterceptor
+
+var valueDepth = traceCommon.DefaultRecordValuesDepth
 
 func getTraceInterceptorSingleton() *methodTraceInterceptor {
 	if methodTraceInterceptorSingleton == nil {

--- a/extension/aop/trace/trace.go
+++ b/extension/aop/trace/trace.go
@@ -46,10 +46,11 @@ func newTrace(grID int64, entranceMethod string) *trace {
 	}
 }
 
-func (t *trace) addChildSpan(name string) {
+func (t *trace) addChildSpan(name string) *spanWithParent {
 	func1Span := getGlobalTracer().getRawTracer().StartSpan(name, opentracing.ChildOf(t.currentSpan.span.Context()), opentracing.StartTime(time.Now()))
 	innerChildSpan := newSpanWithParent(func1Span, t.currentSpan)
 	t.currentSpan = innerChildSpan
+	return t.currentSpan
 }
 
 func (t *trace) returnSpan() {

--- a/iocli/go.mod
+++ b/iocli/go.mod
@@ -3,7 +3,7 @@ module github.com/alibaba/ioc-golang/iocli
 go 1.17
 
 require (
-	github.com/alibaba/ioc-golang/extension v0.0.0-20220711075011-c10ef069080e
+	github.com/alibaba/ioc-golang/extension v0.0.0-20220711080411-55cecceea4dc
 	github.com/gobuffalo/packr/v2 v2.8.3
 	github.com/spf13/cobra v1.5.0
 	sigs.k8s.io/controller-tools v0.9.0

--- a/iocli/go.sum
+++ b/iocli/go.sum
@@ -43,8 +43,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/alibaba/ioc-golang/extension v0.0.0-20220711075011-c10ef069080e h1:fYUV7UNRo1dHgCk1In3f8T0mubwBwUK7qRD/yDqmudA=
-github.com/alibaba/ioc-golang/extension v0.0.0-20220711075011-c10ef069080e/go.mod h1:dz2cOIWsQYjGJmSoS+/5CO0dCbukvoMJDDS2Mtm2/ys=
+github.com/alibaba/ioc-golang/extension v0.0.0-20220711080411-55cecceea4dc h1:LcO3IASUq2+jwB2k0xI5vrnfLMgRseJdKT+URmtmyy8=
+github.com/alibaba/ioc-golang/extension v0.0.0-20220711080411-55cecceea4dc/go.mod h1:dz2cOIWsQYjGJmSoS+/5CO0dCbukvoMJDDS2Mtm2/ys=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
1. Add params and return values snapshot info in spans:
![image](https://user-images.githubusercontent.com/45508533/178496739-63c96319-b594-46d3-9295-664a276668d0.png)

2. Add 'store' param of `iocli trace` command to save recording spans binary to local file.
