### PR TITLE
ftr: add 'this' stub for singleton

### DIFF
--- a/example/aop/dynamic_plugin/complex/plugin_1/zz_generated.ioc.go
+++ b/example/aop/dynamic_plugin/complex/plugin_1/zz_generated.ioc.go
@@ -98,3 +98,11 @@ func GetService2IOCInterfaceSingleton() (Service2IOCInterface, error) {
 	impl := i.(Service2IOCInterface)
 	return impl, nil
 }
+
+type ThisService2 struct {
+}
+
+func (t *ThisService2) This() Service2IOCInterface {
+	thisPtr, _ := GetService2IOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/aop/dynamic_plugin/complex/service1/zz_generated.ioc.go
+++ b/example/aop/dynamic_plugin/complex/service1/zz_generated.ioc.go
@@ -81,6 +81,14 @@ func GetService1IOCInterfaceSingleton() (Service1IOCInterface, error) {
 	return impl, nil
 }
 
+type ThisService1 struct {
+}
+
+func (t *ThisService1) This() Service1IOCInterface {
+	thisPtr, _ := GetService1IOCInterfaceSingleton()
+	return thisPtr
+}
+
 func GetService1() (*Service1, error) {
 	if _service1SDID == "" {
 		_service1SDID = util.GetSDIDByStructPtr(new(Service1))

--- a/example/aop/dynamic_plugin/complex/service2/zz_generated.ioc.go
+++ b/example/aop/dynamic_plugin/complex/service2/zz_generated.ioc.go
@@ -104,3 +104,11 @@ func GetService2IOCInterfaceSingleton() (Service2IOCInterface, error) {
 	impl := i.(Service2IOCInterface)
 	return impl, nil
 }
+
+type ThisService2 struct {
+}
+
+func (t *ThisService2) This() Service2IOCInterface {
+	thisPtr, _ := GetService2IOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/aop/dynamic_plugin/complex/zz_generated.ioc.go
+++ b/example/aop/dynamic_plugin/complex/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/aop/dynamic_plugin/simple/zz_generated.ioc.go
+++ b/example/aop/dynamic_plugin/simple/zz_generated.ioc.go
@@ -95,6 +95,14 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	return impl, nil
 }
 
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _serviceImpl1SDID string
 
 func GetServiceImpl1Singleton() (*ServiceImpl1, error) {
@@ -119,4 +127,12 @@ func GetServiceImpl1IOCInterfaceSingleton() (ServiceImpl1IOCInterface, error) {
 	}
 	impl := i.(ServiceImpl1IOCInterface)
 	return impl, nil
+}
+
+type ThisServiceImpl1 struct {
+}
+
+func (t *ThisServiceImpl1) This() ServiceImpl1IOCInterface {
+	thisPtr, _ := GetServiceImpl1IOCInterfaceSingleton()
+	return thisPtr
 }

--- a/example/aop/observability/zz_generated.ioc.go
+++ b/example/aop/observability/zz_generated.ioc.go
@@ -122,6 +122,14 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	return impl, nil
 }
 
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _serviceImpl1SDID string
 
 func GetServiceImpl1Singleton() (*ServiceImpl1, error) {
@@ -148,6 +156,14 @@ func GetServiceImpl1IOCInterfaceSingleton() (ServiceImpl1IOCInterface, error) {
 	return impl, nil
 }
 
+type ThisServiceImpl1 struct {
+}
+
+func (t *ThisServiceImpl1) This() ServiceImpl1IOCInterface {
+	thisPtr, _ := GetServiceImpl1IOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _serviceImpl2SDID string
 
 func GetServiceImpl2Singleton() (*ServiceImpl2, error) {
@@ -172,4 +188,12 @@ func GetServiceImpl2IOCInterfaceSingleton() (ServiceImpl2IOCInterface, error) {
 	}
 	impl := i.(ServiceImpl2IOCInterface)
 	return impl, nil
+}
+
+type ThisServiceImpl2 struct {
+}
+
+func (t *ThisServiceImpl2) This() ServiceImpl2IOCInterface {
+	thisPtr, _ := GetServiceImpl2IOCInterfaceSingleton()
+	return thisPtr
 }

--- a/example/aop/transaction/distributed/client/zz_generated.ioc.go
+++ b/example/aop/transaction/distributed/client/zz_generated.ioc.go
@@ -113,6 +113,14 @@ func GetTradeServiceIOCInterfaceSingleton() (TradeServiceIOCInterface, error) {
 	return impl, nil
 }
 
+type ThisTradeService struct {
+}
+
+func (t *ThisTradeService) This() TradeServiceIOCInterface {
+	thisPtr, _ := GetTradeServiceIOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _appSDID string
 
 func GetAppSingleton() (*App, error) {
@@ -137,4 +145,12 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	}
 	impl := i.(AppIOCInterface)
 	return impl, nil
+}
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
 }

--- a/example/aop/transaction/singleton/cmd/zz_generated.ioc.go
+++ b/example/aop/transaction/singleton/cmd/zz_generated.ioc.go
@@ -73,3 +73,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/aop/transaction/singleton/service/zz_generated.ioc.go
+++ b/example/aop/transaction/singleton/service/zz_generated.ioc.go
@@ -148,6 +148,14 @@ func GetBankServiceIOCInterfaceSingleton() (BankServiceIOCInterface, error) {
 	return impl, nil
 }
 
+type ThisBankService struct {
+}
+
+func (t *ThisBankService) This() BankServiceIOCInterface {
+	thisPtr, _ := GetBankServiceIOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _tradeServiceSDID string
 
 func GetTradeServiceSingleton() (*TradeService, error) {
@@ -172,4 +180,12 @@ func GetTradeServiceIOCInterfaceSingleton() (TradeServiceIOCInterface, error) {
 	}
 	impl := i.(TradeServiceIOCInterface)
 	return impl, nil
+}
+
+type ThisTradeService struct {
+}
+
+func (t *ThisTradeService) This() TradeServiceIOCInterface {
+	thisPtr, _ := GetTradeServiceIOCInterfaceSingleton()
+	return thisPtr
 }

--- a/example/autowire/autowire_allimpls/zz_generated.ioc.go
+++ b/example/autowire/autowire_allimpls/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/autowire/autowire_config/cmd/zz_generated.ioc.go
+++ b/example/autowire/autowire_config/cmd/zz_generated.ioc.go
@@ -68,3 +68,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/autowire/autowire_rpc/client/zz_generated.ioc.go
+++ b/example/autowire/autowire_rpc/client/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/autowire/get_impl_by_api/cmd/zz_generated.ioc.go
+++ b/example/autowire/get_impl_by_api/cmd/zz_generated.ioc.go
@@ -68,3 +68,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/config_file/activate_profile/zz_generated.ioc.go
+++ b/example/config_file/activate_profile/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/config_file/complex_example/zz_generated.ioc.go
+++ b/example/config_file/complex_example/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/config_file/config_by_api/zz_generated.ioc.go
+++ b/example/config_file/config_by_api/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/config_file/default_config_file/zz_generated.ioc.go
+++ b/example/config_file/default_config_file/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/config_file/mark_env_variable_in_config_file/zz_generated.ioc.go
+++ b/example/config_file/mark_env_variable_in_config_file/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/config_file/mark_nested_value_in_config_file/zz_generated.ioc.go
+++ b/example/config_file/mark_nested_value_in_config_file/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/config_file/set_config_file_search_path/zz_generated.ioc.go
+++ b/example/config_file/set_config_file_search_path/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/config_file/set_config_file_type/zz_generated.ioc.go
+++ b/example/config_file/set_config_file_type/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/config_file/set_config_name/zz_generated.ioc.go
+++ b/example/config_file/set_config_name/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/helloworld/zz_generated.ioc.go
+++ b/example/helloworld/zz_generated.ioc.go
@@ -149,6 +149,14 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	return impl, nil
 }
 
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _serviceImpl1SDID string
 
 func GetServiceImpl1Singleton() (*ServiceImpl1, error) {
@@ -173,6 +181,14 @@ func GetServiceImpl1IOCInterfaceSingleton() (ServiceImpl1IOCInterface, error) {
 	}
 	impl := i.(ServiceImpl1IOCInterface)
 	return impl, nil
+}
+
+type ThisServiceImpl1 struct {
+}
+
+func (t *ThisServiceImpl1) This() ServiceImpl1IOCInterface {
+	thisPtr, _ := GetServiceImpl1IOCInterfaceSingleton()
+	return thisPtr
 }
 
 var _serviceImpl2SDID string
@@ -201,6 +217,14 @@ func GetServiceImpl2IOCInterfaceSingleton() (ServiceImpl2IOCInterface, error) {
 	return impl, nil
 }
 
+type ThisServiceImpl2 struct {
+}
+
+func (t *ThisServiceImpl2) This() ServiceImpl2IOCInterface {
+	thisPtr, _ := GetServiceImpl2IOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _serviceStructSDID string
 
 func GetServiceStructSingleton() (*ServiceStruct, error) {
@@ -225,4 +249,12 @@ func GetServiceStructIOCInterfaceSingleton() (ServiceStructIOCInterface, error) 
 	}
 	impl := i.(ServiceStructIOCInterface)
 	return impl, nil
+}
+
+type ThisServiceStruct struct {
+}
+
+func (t *ThisServiceStruct) This() ServiceStructIOCInterface {
+	thisPtr, _ := GetServiceStructIOCInterfaceSingleton()
+	return thisPtr
 }

--- a/example/third_party/autowire/grpc/cmd/service1/zz_generated.ioc.go
+++ b/example/third_party/autowire/grpc/cmd/service1/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetImpl1IOCInterfaceSingleton() (Impl1IOCInterface, error) {
 	impl := i.(Impl1IOCInterface)
 	return impl, nil
 }
+
+type ThisImpl1 struct {
+}
+
+func (t *ThisImpl1) This() Impl1IOCInterface {
+	thisPtr, _ := GetImpl1IOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/third_party/autowire/grpc/cmd/service2/zz_generated.ioc.go
+++ b/example/third_party/autowire/grpc/cmd/service2/zz_generated.ioc.go
@@ -95,6 +95,14 @@ func GetImpl1IOCInterfaceSingleton() (Impl1IOCInterface, error) {
 	return impl, nil
 }
 
+type ThisImpl1 struct {
+}
+
+func (t *ThisImpl1) This() Impl1IOCInterface {
+	thisPtr, _ := GetImpl1IOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _impl2SDID string
 
 func GetImpl2Singleton() (*Impl2, error) {
@@ -119,4 +127,12 @@ func GetImpl2IOCInterfaceSingleton() (Impl2IOCInterface, error) {
 	}
 	impl := i.(Impl2IOCInterface)
 	return impl, nil
+}
+
+type ThisImpl2 struct {
+}
+
+func (t *ThisImpl2) This() Impl2IOCInterface {
+	thisPtr, _ := GetImpl2IOCInterfaceSingleton()
+	return thisPtr
 }

--- a/example/third_party/autowire/grpc/cmd/struct1/zz_generated.ioc.go
+++ b/example/third_party/autowire/grpc/cmd/struct1/zz_generated.ioc.go
@@ -67,3 +67,11 @@ func GetStruct1IOCInterfaceSingleton() (Struct1IOCInterface, error) {
 	impl := i.(Struct1IOCInterface)
 	return impl, nil
 }
+
+type ThisStruct1 struct {
+}
+
+func (t *ThisStruct1) This() Struct1IOCInterface {
+	thisPtr, _ := GetStruct1IOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/third_party/autowire/grpc/cmd/zz_generated.ioc.go
+++ b/example/third_party/autowire/grpc/cmd/zz_generated.ioc.go
@@ -68,3 +68,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/third_party/db/gorm/cmd/zz_generated.ioc.go
+++ b/example/third_party/db/gorm/cmd/zz_generated.ioc.go
@@ -68,3 +68,11 @@ func GetAppIOCInterfaceSingleton() (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/example/third_party/pubsub/rocketmq/cmd/zz_generated.ioc.go
+++ b/example/third_party/pubsub/rocketmq/cmd/zz_generated.ioc.go
@@ -80,3 +80,11 @@ func GetAppIOCInterfaceSingleton(p *Param) (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton(nil)
+	return thisPtr
+}

--- a/example/third_party/registry/nacos/cmd/zz_generated.ioc.go
+++ b/example/third_party/registry/nacos/cmd/zz_generated.ioc.go
@@ -80,3 +80,11 @@ func GetAppIOCInterfaceSingleton(p *Param) (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton(nil)
+	return thisPtr
+}

--- a/example/third_party/state/redis/cmd/zz_generated.ioc.go
+++ b/example/third_party/state/redis/cmd/zz_generated.ioc.go
@@ -80,3 +80,11 @@ func GetAppIOCInterfaceSingleton(p *Param) (AppIOCInterface, error) {
 	impl := i.(AppIOCInterface)
 	return impl, nil
 }
+
+type ThisApp struct {
+}
+
+func (t *ThisApp) This() AppIOCInterface {
+	thisPtr, _ := GetAppIOCInterfaceSingleton(nil)
+	return thisPtr
+}

--- a/extension/aop/monitor/zz_generated.ioc.go
+++ b/extension/aop/monitor/zz_generated.ioc.go
@@ -279,6 +279,14 @@ func GetinterceptorImplIOCInterfaceSingleton() (interceptorImplIOCInterface, err
 	return impl, nil
 }
 
+type ThisinterceptorImpl struct {
+}
+
+func (t *ThisinterceptorImpl) This() interceptorImplIOCInterface {
+	thisPtr, _ := GetinterceptorImplIOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _monitorServiceSDID string
 
 func GetmonitorServiceSingleton() (*monitorService, error) {
@@ -303,4 +311,12 @@ func GetmonitorServiceIOCInterfaceSingleton() (monitorServiceIOCInterface, error
 	}
 	impl := i.(monitorServiceIOCInterface)
 	return impl, nil
+}
+
+type ThismonitorService struct {
+}
+
+func (t *ThismonitorService) This() monitorServiceIOCInterface {
+	thisPtr, _ := GetmonitorServiceIOCInterfaceSingleton()
+	return thisPtr
 }

--- a/extension/aop/transaction/zz_generated.ioc.go
+++ b/extension/aop/transaction/zz_generated.ioc.go
@@ -225,3 +225,11 @@ func GetinterceptorImplIOCInterfaceSingleton() (interceptorImplIOCInterface, err
 	impl := i.(interceptorImplIOCInterface)
 	return impl, nil
 }
+
+type ThisinterceptorImpl struct {
+}
+
+func (t *ThisinterceptorImpl) This() interceptorImplIOCInterface {
+	thisPtr, _ := GetinterceptorImplIOCInterfaceSingleton()
+	return thisPtr
+}

--- a/extension/aop/watch/zz_generated.ioc.go
+++ b/extension/aop/watch/zz_generated.ioc.go
@@ -157,6 +157,14 @@ func GetinterceptorImplIOCInterfaceSingleton() (interceptorImplIOCInterface, err
 	return impl, nil
 }
 
+type ThisinterceptorImpl struct {
+}
+
+func (t *ThisinterceptorImpl) This() interceptorImplIOCInterface {
+	thisPtr, _ := GetinterceptorImplIOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _contextSDID string
 
 func Getcontext(p *contextParam) (*context, error) {

--- a/extension/config_center/nacos/zz_generated.ioc.go
+++ b/extension/config_center/nacos/zz_generated.ioc.go
@@ -137,3 +137,11 @@ func GetConfigClientIOCInterfaceSingleton(p *Param) (ConfigClientIOCInterface, e
 	impl := i.(ConfigClientIOCInterface)
 	return impl, nil
 }
+
+type ThisConfigClient struct {
+}
+
+func (t *ThisConfigClient) This() ConfigClientIOCInterface {
+	thisPtr, _ := GetConfigClientIOCInterfaceSingleton(nil)
+	return thisPtr
+}

--- a/extension/db/gorm/zz_generated.ioc.go
+++ b/extension/db/gorm/zz_generated.ioc.go
@@ -500,3 +500,11 @@ func GetGORMDBIOCInterfaceSingleton(p *Param) (GORMDBIOCInterface, error) {
 	impl := i.(GORMDBIOCInterface)
 	return impl, nil
 }
+
+type ThisGORMDB struct {
+}
+
+func (t *ThisGORMDB) This() GORMDBIOCInterface {
+	thisPtr, _ := GetGORMDBIOCInterfaceSingleton(nil)
+	return thisPtr
+}

--- a/extension/pubsub/rocketmq/zz_generated.ioc.go
+++ b/extension/pubsub/rocketmq/zz_generated.ioc.go
@@ -245,6 +245,14 @@ func GetPushConsumerIOCInterfaceSingleton(p *PushConsumerParam) (PushConsumerIOC
 	return impl, nil
 }
 
+type ThisPushConsumer struct {
+}
+
+func (t *ThisPushConsumer) This() PushConsumerIOCInterface {
+	thisPtr, _ := GetPushConsumerIOCInterfaceSingleton(nil)
+	return thisPtr
+}
+
 var _producerSDID string
 
 func GetProducer(p *ProducerParam) (*Producer, error) {
@@ -295,6 +303,14 @@ func GetProducerIOCInterfaceSingleton(p *ProducerParam) (ProducerIOCInterface, e
 	return impl, nil
 }
 
+type ThisProducer struct {
+}
+
+func (t *ThisProducer) This() ProducerIOCInterface {
+	thisPtr, _ := GetProducerIOCInterfaceSingleton(nil)
+	return thisPtr
+}
+
 var _adminSDID string
 
 func GetAdmin(p *AdminParam) (*Admin, error) {
@@ -343,4 +359,12 @@ func GetAdminIOCInterfaceSingleton(p *AdminParam) (AdminIOCInterface, error) {
 	}
 	impl := i.(AdminIOCInterface)
 	return impl, nil
+}
+
+type ThisAdmin struct {
+}
+
+func (t *ThisAdmin) This() AdminIOCInterface {
+	thisPtr, _ := GetAdminIOCInterfaceSingleton(nil)
+	return thisPtr
 }

--- a/extension/registry/nacos/zz_generated.ioc.go
+++ b/extension/registry/nacos/zz_generated.ioc.go
@@ -161,3 +161,11 @@ func GetNamingClientIOCInterfaceSingleton(p *Param) (NamingClientIOCInterface, e
 	impl := i.(NamingClientIOCInterface)
 	return impl, nil
 }
+
+type ThisNamingClient struct {
+}
+
+func (t *ThisNamingClient) This() NamingClientIOCInterface {
+	thisPtr, _ := GetNamingClientIOCInterfaceSingleton(nil)
+	return thisPtr
+}

--- a/extension/state/redis/zz_generated.ioc.go
+++ b/extension/state/redis/zz_generated.ioc.go
@@ -1585,3 +1585,11 @@ func GetRedisIOCInterfaceSingleton(p *Param) (RedisIOCInterface, error) {
 	impl := i.(RedisIOCInterface)
 	return impl, nil
 }
+
+type ThisRedis struct {
+}
+
+func (t *ThisRedis) This() RedisIOCInterface {
+	thisPtr, _ := GetRedisIOCInterfaceSingleton(nil)
+	return thisPtr
+}

--- a/iocli/gen/generator/register.go
+++ b/iocli/gen/generator/register.go
@@ -463,6 +463,17 @@ func (c *copyMethodMaker) generateMethodsFor(ctx *genall.GenerationContext, root
 				impl := i.(%sIOCInterface)
 				return impl, nil
 			}`, g.structName, getterSuffix, g.paramTypeName, g.structName, sdidStrName, sdidStrName, utilAlias, g.structName, autowireAliasPair.autowireTypeAlias, sdidStrName, g.structName)
+					if autowireAliasPair.autowireType == "singleton" {
+						// singleton with proxy, generate This struct
+						c.Linef(`type This%s struct {
+}
+
+func (t *This%s) This() %sIOCInterface {
+	thisPtr, _ := Get%sIOCInterface%s(nil)
+	return thisPtr
+}
+`, g.structName, g.structName, g.structName, g.structName, getterSuffix)
+					}
 				}
 				c.Line("")
 			} else {
@@ -499,6 +510,17 @@ func (c *copyMethodMaker) generateMethodsFor(ctx *genall.GenerationContext, root
 			impl := i.(%sIOCInterface)
 			return impl, nil
 			}`, g.structName)
+					if autowireAliasPair.autowireType == "singleton" {
+						// singleton with proxy, generate This struct
+						c.Linef(`type This%s struct {
+}
+
+func (t *This%s) This() %sIOCInterface {
+	thisPtr, _ := Get%sIOCInterface%s()
+	return thisPtr
+}
+`, g.structName, g.structName, g.structName, g.structName, getterSuffix)
+					}
 				}
 				c.Line("")
 			}

--- a/test/stress/aop/recursive_app.go
+++ b/test/stress/aop/recursive_app.go
@@ -18,9 +18,6 @@ package aop
 import (
 	"testing"
 
-	"github.com/alibaba/ioc-golang/autowire/singleton"
-	"github.com/alibaba/ioc-golang/autowire/util"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,6 +25,7 @@ import (
 // +ioc:autowire:type=singleton
 
 type RecursiveApp struct {
+	ThisRecursiveApp
 	// inject main.ServiceImpl1 pointer to Service interface with proxy wrapper
 	ServiceImpl1 Service `normal:"github.com/alibaba/ioc-golang/test/stress/aop.ServiceImpl1"`
 	counter      int
@@ -40,9 +38,7 @@ func (s *RecursiveApp) Reset() {
 func (s *RecursiveApp) RunTest(t *testing.T) {
 	if s.counter < 900 {
 		s.counter++
-		s, err := singleton.GetImplWithProxy(util.GetSDIDByStructPtr(s), nil)
-		assert.Nil(t, err)
-		s.(RecursiveAppIOCInterface).RunTest(t)
+		s.This().RunTest(t)
 		return
 	}
 	assert.Equal(t, expectString, s.ServiceImpl1.GetHelloString(reqString))

--- a/test/stress/aop/zz_generated.ioc.go
+++ b/test/stress/aop/zz_generated.ioc.go
@@ -213,6 +213,14 @@ func GetRecursiveAppIOCInterfaceSingleton() (RecursiveAppIOCInterface, error) {
 	return impl, nil
 }
 
+type ThisRecursiveApp struct {
+}
+
+func (t *ThisRecursiveApp) This() RecursiveAppIOCInterface {
+	thisPtr, _ := GetRecursiveAppIOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _serviceImpl1SDID string
 
 func GetServiceImpl1Singleton() (*ServiceImpl1, error) {
@@ -237,6 +245,14 @@ func GetServiceImpl1IOCInterfaceSingleton() (ServiceImpl1IOCInterface, error) {
 	}
 	impl := i.(ServiceImpl1IOCInterface)
 	return impl, nil
+}
+
+type ThisServiceImpl1 struct {
+}
+
+func (t *ThisServiceImpl1) This() ServiceImpl1IOCInterface {
+	thisPtr, _ := GetServiceImpl1IOCInterfaceSingleton()
+	return thisPtr
 }
 
 func GetServiceImpl1() (*ServiceImpl1, error) {
@@ -289,6 +305,14 @@ func GetServiceImpl2IOCInterfaceSingleton() (ServiceImpl2IOCInterface, error) {
 	return impl, nil
 }
 
+type ThisServiceImpl2 struct {
+}
+
+func (t *ThisServiceImpl2) This() ServiceImpl2IOCInterface {
+	thisPtr, _ := GetServiceImpl2IOCInterfaceSingleton()
+	return thisPtr
+}
+
 func GetServiceImpl2() (*ServiceImpl2, error) {
 	if _serviceImpl2SDID == "" {
 		_serviceImpl2SDID = util.GetSDIDByStructPtr(new(ServiceImpl2))
@@ -337,6 +361,14 @@ func GetServiceStructIOCInterfaceSingleton() (ServiceStructIOCInterface, error) 
 	}
 	impl := i.(ServiceStructIOCInterface)
 	return impl, nil
+}
+
+type ThisServiceStruct struct {
+}
+
+func (t *ThisServiceStruct) This() ServiceStructIOCInterface {
+	thisPtr, _ := GetServiceStructIOCInterfaceSingleton()
+	return thisPtr
 }
 
 func GetServiceStruct() (*ServiceStruct, error) {

--- a/test/stress/autowire/zz_generated.ioc.go
+++ b/test/stress/autowire/zz_generated.ioc.go
@@ -207,6 +207,14 @@ func GetServiceImpl1IOCInterfaceSingleton() (ServiceImpl1IOCInterface, error) {
 	return impl, nil
 }
 
+type ThisServiceImpl1 struct {
+}
+
+func (t *ThisServiceImpl1) This() ServiceImpl1IOCInterface {
+	thisPtr, _ := GetServiceImpl1IOCInterfaceSingleton()
+	return thisPtr
+}
+
 func GetServiceImpl1() (*ServiceImpl1, error) {
 	if _serviceImpl1SDID == "" {
 		_serviceImpl1SDID = util.GetSDIDByStructPtr(new(ServiceImpl1))
@@ -255,6 +263,14 @@ func GetServiceImpl2IOCInterfaceSingleton() (ServiceImpl2IOCInterface, error) {
 	}
 	impl := i.(ServiceImpl2IOCInterface)
 	return impl, nil
+}
+
+type ThisServiceImpl2 struct {
+}
+
+func (t *ThisServiceImpl2) This() ServiceImpl2IOCInterface {
+	thisPtr, _ := GetServiceImpl2IOCInterfaceSingleton()
+	return thisPtr
 }
 
 func GetServiceImpl2() (*ServiceImpl2, error) {
@@ -307,6 +323,14 @@ func GetServiceStructIOCInterfaceSingleton() (ServiceStructIOCInterface, error) 
 	return impl, nil
 }
 
+type ThisServiceStruct struct {
+}
+
+func (t *ThisServiceStruct) This() ServiceStructIOCInterface {
+	thisPtr, _ := GetServiceStructIOCInterfaceSingleton()
+	return thisPtr
+}
+
 func GetServiceStruct() (*ServiceStruct, error) {
 	if _serviceStructSDID == "" {
 		_serviceStructSDID = util.GetSDIDByStructPtr(new(ServiceStruct))
@@ -355,4 +379,12 @@ func GetSingletonAppIOCInterfaceSingleton() (SingletonAppIOCInterface, error) {
 	}
 	impl := i.(SingletonAppIOCInterface)
 	return impl, nil
+}
+
+type ThisSingletonApp struct {
+}
+
+func (t *ThisSingletonApp) This() SingletonAppIOCInterface {
+	thisPtr, _ := GetSingletonAppIOCInterfaceSingleton()
+	return thisPtr
 }

--- a/test/stress/panic/zz_generated.ioc.go
+++ b/test/stress/panic/zz_generated.ioc.go
@@ -141,6 +141,14 @@ func GetafterIsCalledAfterPanicTestInterceptorIOCInterfaceSingleton() (afterIsCa
 	return impl, nil
 }
 
+type ThisafterIsCalledAfterPanicTestInterceptor struct {
+}
+
+func (t *ThisafterIsCalledAfterPanicTestInterceptor) This() afterIsCalledAfterPanicTestInterceptorIOCInterface {
+	thisPtr, _ := GetafterIsCalledAfterPanicTestInterceptorIOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _panicAfterCalledTestSubAppSDID string
 
 func GetPanicAfterCalledTestSubAppSingleton() (*PanicAfterCalledTestSubApp, error) {
@@ -167,6 +175,14 @@ func GetPanicAfterCalledTestSubAppIOCInterfaceSingleton() (PanicAfterCalledTestS
 	return impl, nil
 }
 
+type ThisPanicAfterCalledTestSubApp struct {
+}
+
+func (t *ThisPanicAfterCalledTestSubApp) This() PanicAfterCalledTestSubAppIOCInterface {
+	thisPtr, _ := GetPanicAfterCalledTestSubAppIOCInterfaceSingleton()
+	return thisPtr
+}
+
 var _panicAfterCalledTestAppSDID string
 
 func GetPanicAfterCalledTestAppSingleton() (*PanicAfterCalledTestApp, error) {
@@ -191,4 +207,12 @@ func GetPanicAfterCalledTestAppIOCInterfaceSingleton() (PanicAfterCalledTestAppI
 	}
 	impl := i.(PanicAfterCalledTestAppIOCInterface)
 	return impl, nil
+}
+
+type ThisPanicAfterCalledTestApp struct {
+}
+
+func (t *ThisPanicAfterCalledTestApp) This() PanicAfterCalledTestAppIOCInterface {
+	thisPtr, _ := GetPanicAfterCalledTestAppIOCInterfaceSingleton()
+	return thisPtr
 }


### PR DESCRIPTION
Take stress/aop/recrusive_app.go as an example:
```go
// +ioc:autowire=true
// +ioc:autowire:type=singleton

type RecursiveApp struct {
	ThisRecursiveApp
	// inject main.ServiceImpl1 pointer to Service interface with proxy wrapper
	ServiceImpl1 Service `normal:"github.com/alibaba/ioc-golang/test/stress/aop.ServiceImpl1"`
	counter      int
}

func (s *RecursiveApp) RunTest(t *testing.T) {
	if s.counter < 900 {
		s.counter++
		s.This().RunTest(t) // call it's own proxy function
		return
	}
}
```