### PR TITLE
Fix: trace big object cost too much time bug

### DIFF
--- a/aop/common/util.go
+++ b/aop/common/util.go
@@ -54,15 +54,15 @@ func dumpSingletValue(val reflect.Value, maxDepth, maxLength int) string {
 	if !val.IsValid() {
 		return "nil"
 	}
+	if maxDepth <= 0 {
+		return fmt.Sprintf("%+v", val.Interface())
+	}
 	cfg := spew.NewDefaultConfig()
 	cfg.DisablePointerAddresses = true
 	cfg.MaxDepth = maxDepth
 	cfg.SortKeys = true
 	dumpedStr := cfg.Sdump(val.Interface())
 	if len(dumpedStr) > maxLength {
-		if maxDepth == 0 {
-			return ""
-		}
 		dumpedStr = dumpSingletValue(val, maxDepth-1, maxLength)
 	}
 	return dumpedStr

--- a/extension/aop/trace/transport/collector.go
+++ b/extension/aop/trace/transport/collector.go
@@ -64,6 +64,9 @@ func initStorageFactory() error {
 		SpanReaderType:          memoryStorageType,
 		DependenciesStorageType: memoryStorageType,
 	})
+	if err != nil {
+		return err
+	}
 
 	newStorageFactory.InitFromViper(v, logger)
 	if err := newStorageFactory.Initialize(metrics.NullFactory, logger); err != nil {

--- a/extension/config/zz_generated.ioc.go
+++ b/extension/config/zz_generated.ioc.go
@@ -158,9 +158,6 @@ func init() {
 	autowireconfig.RegisterStructDescriptor(configStringStructDescriptor)
 }
 
-type configStringInterface interface {
-	new(impl *ConfigString) (*ConfigString, error)
-}
 type configFloat64Interface interface {
 	new(impl *ConfigFloat64) (*ConfigFloat64, error)
 }
@@ -175,6 +172,9 @@ type configMapInterface interface {
 }
 type configSliceInterface interface {
 	new(impl *ConfigSlice) (*ConfigSlice, error)
+}
+type configStringInterface interface {
+	new(impl *ConfigString) (*ConfigString, error)
 }
 type configFloat64_ struct {
 	Value_ func() float64

--- a/extension/pubsub/rocketmq/zz_generated.ioc.go
+++ b/extension/pubsub/rocketmq/zz_generated.ioc.go
@@ -96,14 +96,14 @@ func init() {
 	singleton.RegisterStructDescriptor(adminStructDescriptor)
 }
 
+type pushConsumerParamInterface interface {
+	New(impl *PushConsumer) (*PushConsumer, error)
+}
 type producerParamInterface interface {
 	New(impl *Producer) (*Producer, error)
 }
 type adminParamInterface interface {
 	New(impl *Admin) (*Admin, error)
-}
-type pushConsumerParamInterface interface {
-	New(impl *PushConsumer) (*PushConsumer, error)
 }
 type pushConsumer_ struct {
 	Start_       func() error


### PR DESCRIPTION
When go-spew dump big object with depth 0 (no limit), it  cause too much time. 
With depth 0, we just print the object using fmt.Sprintf()